### PR TITLE
Fix: Fetch tags before extracting version in release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fetch tags
+        run: git fetch --tags
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
Problem:
- When release-on-merge workflow creates a new tag (e.g., v0.0.8), the tag is not immediately available in the local repository
- The "Extract version from tag" step then finds the previous tag (v0.0.7)
- This causes Docker images to be tagged with the wrong version

Solution:
- Add "git fetch --tags" step after "Create Release"
- This ensures the newly created tag is available before extraction
- Docker images will now be tagged with the correct version

This fixes the issue where release v0.0.8 was published with Docker image tag 0.0.7.
