### PR TITLE
Fix: Add missing Dockerfile path in manual-docker-build workflow

### DIFF
--- a/.github/workflows/manual-docker-build.yml
+++ b/.github/workflows/manual-docker-build.yml
@@ -48,6 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ./docker/Dockerfile.build
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |


### PR DESCRIPTION
Problem:
- Manual Docker build workflow failed with "open Dockerfile: no such file or directory"
- The workflow was missing the 'file' parameter pointing to docker/Dockerfile.build
- Docker build action defaults to looking for 'Dockerfile' in the root directory

Solution:
- Add 'file: ./docker/Dockerfile.build' parameter to build-push-action
- This matches the configuration in release-on-merge.yml workflow
- Manual Docker builds will now work correctly