### PR TITLE
Add Docker image metadata and descriptions

### DIFF
--- a/.github/workflows/manual-docker-build.yml
+++ b/.github/workflows/manual-docker-build.yml
@@ -73,6 +73,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.version.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/pr-docker-build.yml
+++ b/.github/workflows/pr-docker-build.yml
@@ -39,6 +39,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/n8n-openai-bridge:pr-${{ github.event.pull_request.number }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            DESCRIPTION=PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -103,6 +103,27 @@ jobs:
           # Update release
           gh release edit "$TAG" --notes "$UPDATED_BODY"
 
+      - name: Extract Release Description
+        id: release_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Get the release body (description)
+          RELEASE_BODY=$(gh release view "$TAG" --json body -q .body)
+
+          # Extract just the first line or first paragraph as description
+          # Remove markdown headers and keep only the meaningful description
+          DESCRIPTION=$(echo "$RELEASE_BODY" | grep -v "^#" | grep -v "^docker pull" | grep -v "^\`\`\`" | grep -v "^See \[" | head -n 1 | xargs)
+
+          # If description is empty, use default
+          if [ -z "$DESCRIPTION" ]; then
+            DESCRIPTION="OpenAI-compatible API bridge for n8n workflows - Release ${{ steps.version.outputs.version }}"
+          fi
+
+          echo "description=$DESCRIPTION" >> $GITHUB_OUTPUT
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -115,5 +136,10 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/n8n-openai-bridge:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository_owner }}/n8n-openai-bridge:${{ steps.version.outputs.minor }}
             ghcr.io/${{ github.repository_owner }}/n8n-openai-bridge:${{ steps.version.outputs.major }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            DESCRIPTION=${{ steps.release_info.outputs.description }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,5 +1,23 @@
 FROM node:20-alpine
 
+# Build arguments for image metadata
+ARG VERSION=unknown
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
+ARG DESCRIPTION="OpenAI-compatible API bridge for n8n workflows"
+
+# OCI standard labels
+LABEL org.opencontainers.image.title="n8n-openai-bridge"
+LABEL org.opencontainers.image.description="${DESCRIPTION}"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
+LABEL org.opencontainers.image.source="https://github.com/sveneisenschmidt/n8n-openai-bridge"
+LABEL org.opencontainers.image.url="https://github.com/sveneisenschmidt/n8n-openai-bridge"
+LABEL org.opencontainers.image.documentation="https://github.com/sveneisenschmidt/n8n-openai-bridge#readme"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="Sven Eisenschmidt"
+
 # Set production environment
 ENV NODE_ENV=production
 


### PR DESCRIPTION
- Add OCI standard labels to Dockerfile.build for better image metadata
- Update release-on-merge.yml to extract and use release description from GitHub release tags
- Update manual-docker-build.yml and pr-docker-build.yml to include version and build metadata
- Docker images will now display proper descriptions when published on GHCR

The release workflow will now use the description from the GitHub release tag when building Docker images.