### PR TITLE
Add task detection for OpenWebUI and LibreChat automated requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ MODELS_CONFIG_FILE=./models.json
 # Logging (set to 'true' to enable detailed request logging)
 LOG_REQUESTS=false
 
+# Task Detection (set to 'true' to enable automatic task detection)
+# Detects if incoming requests are automated tasks like title/tags generation
+# from OpenWebUI, LibreChat, etc. and adds taskType field to n8n payload
+ENABLE_TASK_DETECTION=false
+
 # Session ID Headers (comma-separated list, first found wins)
 SESSION_ID_HEADERS=X-Session-Id,X-Chat-Id,X-OpenWebUI-Chat-Id
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Client → Auth Middleware → Route Handler → n8nClient → n8n Webhook
 - `ModelLoaderFactory.js` - Creates loaders based on `MODEL_LOADER_TYPE`
 - `server.js` - Express setup, OpenAI endpoints
 - `n8nClient.js` - n8n webhook communication
+- `taskDetectorService.js` - Detects automated task generation requests (optional)
 
 **Model Loading System:**
 - `JsonFileModelLoader` (TYPE: `file`) - Default, reads `models.json`, hash-based hot-reload
@@ -215,6 +216,9 @@ USER_ID_HEADERS=X-User-Id
 USER_EMAIL_HEADERS=X-User-Email
 USER_NAME_HEADERS=X-User-Name
 USER_ROLE_HEADERS=X-User-Role
+
+# Task Detection (Optional)
+ENABLE_TASK_DETECTION=false               # Detect automated task generation requests
 
 # Webhook Notifier (optional)
 WEBHOOK_NOTIFIER_URL=https://example.com/webhook

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -129,6 +129,68 @@ USER_ROLE_HEADERS=X-User-Role
 
 See [Session Management](#session-management) and [User Context](#user-context) sections below.
 
+### Task Detection
+
+Automatically detect if incoming requests are automated task generation requests from OpenWebUI, LibreChat, or similar clients:
+
+```bash
+# Task Detection Configuration
+ENABLE_TASK_DETECTION=false      # Set to 'true' to enable (default: false)
+```
+
+**What it does:**
+- Analyzes incoming chat completion requests to detect automated tasks
+- Adds `isTask` and `taskType` fields to the n8n webhook payload
+- Helps differentiate between regular user messages and automated generation tasks
+
+**Supported Task Types:**
+- `generate_title` - Title generation (OpenWebUI, LibreChat)
+- `generate_tags` - Tags generation (OpenWebUI)
+- `generate_follow_up_questions` - Follow-up questions (OpenWebUI)
+
+**Task Detection Fields Added to Payload:**
+
+Normal conversation:
+```json
+{
+  "isTask": false,
+  "taskType": null
+}
+```
+
+Title generation detected:
+```json
+{
+  "isTask": true,
+  "taskType": "generate_title"
+}
+```
+
+Tags generation detected:
+```json
+{
+  "isTask": true,
+  "taskType": "generate_tags"
+}
+```
+
+Follow-up questions detected:
+```json
+{
+  "isTask": true,
+  "taskType": "generate_follow_up_questions"
+}
+```
+
+**Use Cases:**
+- Route tasks to different AI agents (use faster/cheaper models for tasks)
+- Separate memory storage for tasks vs. conversations
+- Apply different system prompts for automated tasks
+- Track and analyze automated vs. manual interactions
+
+**See Also:**
+- [How To: Use Task Detection in n8n Workflows](howto/TASK_DETECTION.md) - Practical examples with IF nodes and memory separation
+
 ### Webhook Notifier
 
 Get notified via webhook when models change (hot-reload or auto-discovery):

--- a/docs/howto/TASK_DETECTION.md
+++ b/docs/howto/TASK_DETECTION.md
@@ -1,0 +1,80 @@
+# How To: Use Task Detection in n8n Workflows
+
+Task detection automatically identifies automated generation requests (title, tags, follow-up questions) from OpenWebUI and LibreChat, adding `isTask` and `taskType` fields to the webhook payload.
+
+## Prerequisites
+
+Enable task detection in your bridge configuration:
+
+```bash
+ENABLE_TASK_DETECTION=true
+```
+
+## Example 1: Route Tasks to Different AI Agents
+
+Use an **IF node** to route task generation requests to specialized agents:
+
+```
+Webhook Trigger
+    ↓
+IF Node: {{ $json.isTask }}
+    ├─ TRUE  → Specialized Task Agent (fast, simple model)
+    └─ FALSE → Regular Conversation Agent (full context)
+```
+
+**IF Node Configuration:**
+- Condition: `{{ $json.isTask }}` equals `true`
+- True branch: Connect to task-optimized AI node
+- False branch: Connect to regular conversation AI node
+
+## Example 2: Separate Memory Storage by Task Type
+
+Use **Memory Store nodes** to keep task generations separate from conversations:
+
+**Memory Key Expression:**
+```javascript
+{{ !$json.isTask ? $json.sessionId : `${$json.taskType}-${$json.sessionId}` }}
+```
+
+**Results:**
+- Normal conversation: `session-abc123`
+- Title generation: `generate_title-session-abc123`
+- Tags generation: `generate_tags-session-abc123`
+- Follow-up questions: `generate_follow_up_questions-session-abc123`
+
+**Why?** This prevents task generation context from polluting regular conversation memory.
+
+## Available Task Types
+
+| `taskType` Value | Description | Clients |
+|------------------|-------------|---------|
+| `generate_title` | Title generation | OpenWebUI, LibreChat |
+| `generate_tags` | Tags generation | OpenWebUI |
+| `generate_follow_up_questions` | Follow-up questions | OpenWebUI |
+| `null` | Normal conversation | All |
+
+## Complete Workflow Example
+
+```
+1. Webhook Trigger (receives request from bridge)
+2. IF Node: Check isTask
+   ├─ TRUE:
+   │   ├─ Memory Node (key: taskType + "-" + sessionId)
+   │   └─ Fast AI Model (gpt-3.5-turbo)
+   └─ FALSE:
+       ├─ Memory Node (key: sessionId)
+       └─ Advanced AI Model (gpt-4)
+3. Return response to bridge
+```
+
+## Tips
+
+- **Performance:** Use faster/cheaper models for task generation
+- **Context:** Task requests don't need full conversation history
+- **Memory:** Separate storage prevents context pollution
+- **Routing:** Different system prompts for tasks vs. conversations
+
+## Related
+
+- [Configuration Guide](../CONFIGURATION.md#task-detection) - Enable task detection
+- [n8n Setup](../N8N_SETUP.md) - Webhook configuration

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -40,6 +40,9 @@ class Config {
     this.n8nWebhookBearerToken = this.resolveN8nWebhookBearerToken();
     this.logRequests = process.env.LOG_REQUESTS === 'true';
 
+    // Task detection configuration
+    this.enableTaskDetection = process.env.ENABLE_TASK_DETECTION === 'true';
+
     // Header configuration
     this.sessionIdHeaders = this.parseSessionIdHeaders();
     this.userIdHeaders = this.parseUserIdHeaders();

--- a/src/constants/TaskType.js
+++ b/src/constants/TaskType.js
@@ -1,0 +1,29 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Task type constants for detecting automated generation tasks
+ * from OpenWebUI, LibreChat, and similar clients
+ */
+const TaskType = Object.freeze({
+  GENERATE_TITLE: 'generate_title',
+  GENERATE_TAGS: 'generate_tags',
+  GENERATE_FOLLOW_UP_QUESTIONS: 'generate_follow_up_questions',
+});
+
+module.exports = TaskType;

--- a/src/detectors/createDetector.js
+++ b/src/detectors/createDetector.js
@@ -1,0 +1,49 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Creates a detector function based on regex pattern groups
+ *
+ * @param {Array<Array<RegExp>>} patternGroups - Array of pattern groups
+ *   Each group is an array of regex patterns where ALL must match
+ *   The task is detected if ANY group matches completely
+ * @returns {Function} Detector function that takes messages array
+ */
+function createDetector(patternGroups) {
+  return function detect(messages) {
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return false;
+    }
+
+    // Check system message and last user message
+    const messagesToCheck = [
+      messages.find((m) => m.role === 'system')?.content || '',
+      messages[messages.length - 1]?.content || '',
+    ];
+
+    const combinedContent = messagesToCheck.join(' ');
+
+    // Check if ANY pattern group matches completely
+    return patternGroups.some((patternGroup) => {
+      // ALL patterns in this group must match
+      return patternGroup.every((pattern) => pattern.test(combinedContent));
+    });
+  };
+}
+
+module.exports = createDetector;

--- a/src/detectors/detectorRegistry.js
+++ b/src/detectors/detectorRegistry.js
@@ -1,0 +1,61 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const TaskType = require('../constants/TaskType');
+
+/**
+ * Task detector registry for all supported clients
+ *
+ * Structure:
+ * {
+ *   [TaskType]: [
+ *     [pattern1, pattern2, ...],  // Pattern group 1: ALL patterns must match
+ *     [pattern3, pattern4, ...],  // Pattern group 2: ALL patterns must match
+ *   ]
+ * }
+ *
+ * A task is detected if ANY pattern group matches completely (all patterns in that group match)
+ *
+ * Each pattern group should have a comment indicating which client/template it matches
+ */
+const detectorRegistry = {
+  [TaskType.GENERATE_TITLE]: [
+    // OpenWebUI: "Generate a concise, 3-5 word title with an emoji summarizing the chat history."
+    [/generate a concise.*3-5 word title.*emoji/i, /<chat_history>/i, /<\/chat_history>/i],
+    // LibreChat: "Provide a concise, 5-word-or-less title for the conversation..."
+    [
+      /provide a concise.*5-word-or-less title/i,
+      /title case conventions/i,
+      /only return the title itself/i,
+    ],
+  ],
+
+  [TaskType.GENERATE_TAGS]: [
+    // OpenWebUI: "Generate 1-3 broad tags categorizing the main themes..."
+    [/generate.*1-3.*broad tags.*categorizing/i, /<chat_history>/i, /<\/chat_history>/i],
+    // LibreChat: Add patterns here when templates are available
+  ],
+
+  [TaskType.GENERATE_FOLLOW_UP_QUESTIONS]: [
+    // OpenWebUI: "Suggest 3-5 relevant follow-up questions..."
+    [/suggest.*3-5.*follow[-\s]?up questions/i, /<chat_history>/i, /<\/chat_history>/i],
+    // LibreChat: Add patterns here when templates are available
+  ],
+};
+
+module.exports = detectorRegistry;

--- a/src/server.js
+++ b/src/server.js
@@ -36,7 +36,7 @@ const adminReloadRoute = require('./routes/adminReload');
 
 const app = express();
 const bootstrap = new Bootstrap();
-const n8nClient = new N8nClient(bootstrap.config);
+const n8nClient = new N8nClient(bootstrap.config, bootstrap.taskDetectorService);
 
 // Store bootstrap and n8nClient in app.locals for access in routes
 app.locals.bootstrap = bootstrap;

--- a/src/services/taskDetectorService.js
+++ b/src/services/taskDetectorService.js
@@ -1,0 +1,79 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Service for detecting automated task generation requests
+ * from OpenWebUI, LibreChat, and similar clients.
+ *
+ * Uses a callback-based registry pattern to allow extensibility.
+ */
+class TaskDetectorService {
+  constructor() {
+    this.detectors = new Map();
+  }
+
+  /**
+   * Registers a task detector callback
+   *
+   * @param {string} taskType - Task type from TaskType enum
+   * @param {Function} callback - Detection function (messages) => boolean
+   */
+  registerDetector(taskType, callback) {
+    if (typeof callback !== 'function') {
+      throw new Error('Detector callback must be a function');
+    }
+    this.detectors.set(taskType, callback);
+  }
+
+  /**
+   * Detects if messages represent an automated task
+   *
+   * @param {Array<Object>} messages - Chat messages array
+   * @returns {Object} { isTask: boolean, taskType: string|null }
+   */
+  detectTask(messages) {
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return { isTask: false, taskType: null };
+    }
+
+    // Run all registered detectors
+    for (const [taskType, detector] of this.detectors.entries()) {
+      try {
+        if (detector(messages)) {
+          return { isTask: true, taskType };
+        }
+      } catch (error) {
+        console.error(
+          `[${new Date().toISOString()}] Task detector error for ${taskType}:`,
+          error.message,
+        );
+      }
+    }
+
+    return { isTask: false, taskType: null };
+  }
+
+  /**
+   * Clears all registered detectors (useful for testing)
+   */
+  clearDetectors() {
+    this.detectors.clear();
+  }
+}
+
+module.exports = TaskDetectorService;

--- a/tests/detectors/createDetector.test.js
+++ b/tests/detectors/createDetector.test.js
@@ -1,0 +1,267 @@
+const createDetector = require('../../src/detectors/createDetector');
+
+describe('createDetector', () => {
+  describe('basic functionality', () => {
+    test('should return a function', () => {
+      const patternGroups = [[/test/i]];
+      const detector = createDetector(patternGroups);
+
+      expect(typeof detector).toBe('function');
+    });
+
+    test('should return false for empty messages array', () => {
+      const patternGroups = [[/test/i]];
+      const detector = createDetector(patternGroups);
+
+      const result = detector([]);
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false for non-array input', () => {
+      const patternGroups = [[/test/i]];
+      const detector = createDetector(patternGroups);
+
+      expect(detector(null)).toBe(false);
+      expect(detector(undefined)).toBe(false);
+      expect(detector('not-array')).toBe(false);
+      expect(detector({})).toBe(false);
+    });
+  });
+
+  describe('single pattern group', () => {
+    test('should detect when single pattern matches', () => {
+      const patternGroups = [[/generate.*title/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [{ role: 'user', content: 'Generate a title for this' }];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should not detect when pattern does not match', () => {
+      const patternGroups = [[/generate.*title/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [{ role: 'user', content: 'Hello world' }];
+
+      expect(detector(messages)).toBe(false);
+    });
+
+    test('should require all patterns in group to match', () => {
+      const patternGroups = [[/generate/i, /title/i, /emoji/i]];
+      const detector = createDetector(patternGroups);
+
+      // All patterns match
+      expect(detector([{ role: 'user', content: 'Generate title with emoji' }])).toBe(true);
+
+      // Only 2 out of 3 patterns match
+      expect(detector([{ role: 'user', content: 'Generate title' }])).toBe(false);
+
+      // Only 1 out of 3 patterns match
+      expect(detector([{ role: 'user', content: 'Generate something' }])).toBe(false);
+    });
+  });
+
+  describe('multiple pattern groups', () => {
+    test('should detect when any pattern group matches completely', () => {
+      const patternGroups = [
+        [/openwebui/i, /title/i], // Group 1
+        [/librechat/i, /title/i], // Group 2
+      ];
+      const detector = createDetector(patternGroups);
+
+      // First group matches
+      expect(detector([{ role: 'user', content: 'OpenWebUI title generation' }])).toBe(true);
+
+      // Second group matches
+      expect(detector([{ role: 'user', content: 'LibreChat title generation' }])).toBe(true);
+
+      // Neither group matches completely
+      expect(detector([{ role: 'user', content: 'OpenWebUI tags' }])).toBe(false);
+    });
+
+    test('should return true if at least one group matches', () => {
+      const patternGroups = [
+        [/pattern1/i, /pattern2/i],
+        [/pattern3/i, /pattern4/i],
+        [/pattern5/i, /pattern6/i],
+      ];
+      const detector = createDetector(patternGroups);
+
+      // Only middle group matches
+      const messages = [{ role: 'user', content: 'pattern3 and pattern4' }];
+
+      expect(detector(messages)).toBe(true);
+    });
+  });
+
+  describe('message checking', () => {
+    test('should check system message content', () => {
+      const patternGroups = [[/system.*instruction/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        { role: 'system', content: 'System instruction here' },
+        { role: 'user', content: 'Hello' },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should check last user message content', () => {
+      const patternGroups = [[/last.*message/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        { role: 'user', content: 'First message' },
+        { role: 'assistant', content: 'Response' },
+        { role: 'user', content: 'Last message here' },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should check both system and last message combined', () => {
+      const patternGroups = [[/system/i, /user/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        { role: 'system', content: 'System prompt' },
+        { role: 'user', content: 'User message' },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should handle messages without system role', () => {
+      const patternGroups = [[/hello/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [{ role: 'user', content: 'Hello world' }];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should handle empty content in messages', () => {
+      const patternGroups = [[/test/i]];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        { role: 'system', content: '' },
+        { role: 'user', content: 'test' },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+  });
+
+  describe('real-world patterns', () => {
+    test('should detect OpenWebUI title generation', () => {
+      const patternGroups = [
+        [/generate a concise.*3-5 word title.*emoji/i, /<chat_history>/i, /<\/chat_history>/i],
+      ];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'Generate a concise, 3-5 word title with an emoji summarizing the chat history.\n<chat_history>\n{{MESSAGES:END:2}}\n</chat_history>',
+        },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should detect LibreChat title generation', () => {
+      const patternGroups = [
+        [
+          /provide a concise.*5-word-or-less title/i,
+          /title case conventions/i,
+          /only return the title itself/i,
+        ],
+      ];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        {
+          role: 'user',
+          content:
+            'Provide a concise, 5-word-or-less title for the conversation, using title case conventions. Only return the title itself.',
+        },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should detect OpenWebUI tags generation', () => {
+      const patternGroups = [
+        [/generate.*1-3.*broad tags.*categorizing/i, /<chat_history>/i, /<\/chat_history>/i],
+      ];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'Generate 1-3 broad tags categorizing the main themes...\n<chat_history>\n{{MESSAGES:END:6}}\n</chat_history>',
+        },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should detect OpenWebUI follow-up questions', () => {
+      const patternGroups = [
+        [/suggest.*3-5.*follow[-\s]?up questions/i, /<chat_history>/i, /<\/chat_history>/i],
+      ];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'Suggest 3-5 relevant follow-up questions...\n<chat_history>\n{{MESSAGES:END:6}}\n</chat_history>',
+        },
+      ];
+
+      expect(detector(messages)).toBe(true);
+    });
+
+    test('should not detect normal conversation', () => {
+      const patternGroups = [
+        [/generate a concise.*3-5 word title.*emoji/i, /<chat_history>/i],
+        [/provide a concise.*5-word-or-less title/i, /title case conventions/i],
+      ];
+      const detector = createDetector(patternGroups);
+
+      const messages = [
+        { role: 'user', content: 'Hello, how are you?' },
+        { role: 'assistant', content: 'I am doing well, thank you!' },
+        { role: 'user', content: 'Can you help me with something?' },
+      ];
+
+      expect(detector(messages)).toBe(false);
+    });
+  });
+
+  describe('case sensitivity', () => {
+    test('should be case-insensitive when using /i flag', () => {
+      const patternGroups = [[/GENERATE/i, /TITLE/i]];
+      const detector = createDetector(patternGroups);
+
+      expect(detector([{ role: 'user', content: 'generate title' }])).toBe(true);
+      expect(detector([{ role: 'user', content: 'GENERATE TITLE' }])).toBe(true);
+      expect(detector([{ role: 'user', content: 'Generate Title' }])).toBe(true);
+    });
+
+    test('should be case-sensitive without /i flag', () => {
+      const patternGroups = [[/Generate/, /Title/]];
+      const detector = createDetector(patternGroups);
+
+      expect(detector([{ role: 'user', content: 'Generate Title' }])).toBe(true);
+      expect(detector([{ role: 'user', content: 'generate title' }])).toBe(false);
+    });
+  });
+});

--- a/tests/n8n-client/task-detection.test.js
+++ b/tests/n8n-client/task-detection.test.js
@@ -1,0 +1,235 @@
+const N8nClient = require('../../src/n8nClient');
+const Config = require('../../src/config/Config');
+const TaskDetectorService = require('../../src/services/taskDetectorService');
+const TaskType = require('../../src/constants/TaskType');
+
+describe('N8nClient - Task Detection', () => {
+  let config;
+  let taskDetectorService;
+  let n8nClient;
+
+  beforeEach(() => {
+    config = new Config();
+    taskDetectorService = new TaskDetectorService();
+  });
+
+  describe('buildPayload with task detection disabled', () => {
+    beforeEach(() => {
+      config.enableTaskDetection = false;
+      n8nClient = new N8nClient(config, taskDetectorService);
+    });
+
+    test('should include default task fields when detection is disabled', () => {
+      const messages = [{ role: 'user', content: 'Generate a title' }];
+      const sessionId = 'test-session';
+      const userContext = { userId: 'user-123' };
+
+      const payload = n8nClient.buildPayload(messages, sessionId, userContext);
+
+      expect(payload.isTask).toBe(false);
+      expect(payload.taskType).toBe(null);
+    });
+
+    test('should not call task detector when disabled', () => {
+      const detectSpy = jest.spyOn(taskDetectorService, 'detectTask');
+      const messages = [{ role: 'user', content: 'Test' }];
+
+      n8nClient.buildPayload(messages, 'session', { userId: 'user' });
+
+      expect(detectSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildPayload with task detection enabled', () => {
+    beforeEach(() => {
+      config.enableTaskDetection = true;
+      n8nClient = new N8nClient(config, taskDetectorService);
+    });
+
+    test('should detect OpenWebUI title generation task', () => {
+      const titleDetector = jest.fn().mockReturnValue(true);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'Generate a concise, 3-5 word title with an emoji.\n<chat_history>\nHistory here\n</chat_history>',
+        },
+      ];
+
+      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+
+      expect(payload.isTask).toBe(true);
+      expect(payload.taskType).toBe(TaskType.GENERATE_TITLE);
+      expect(titleDetector).toHaveBeenCalledWith(messages);
+    });
+
+    test('should detect tags generation task', () => {
+      const tagsDetector = jest.fn().mockReturnValue(true);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TAGS, tagsDetector);
+
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'Generate 1-3 broad tags categorizing...\n<chat_history>\nHistory\n</chat_history>',
+        },
+      ];
+
+      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+
+      expect(payload.isTask).toBe(true);
+      expect(payload.taskType).toBe(TaskType.GENERATE_TAGS);
+    });
+
+    test('should detect follow-up questions task', () => {
+      const followUpDetector = jest.fn().mockReturnValue(true);
+      taskDetectorService.registerDetector(TaskType.GENERATE_FOLLOW_UP_QUESTIONS, followUpDetector);
+
+      const messages = [
+        {
+          role: 'system',
+          content:
+            'Suggest 3-5 relevant follow-up questions...\n<chat_history>\nHistory\n</chat_history>',
+        },
+      ];
+
+      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+
+      expect(payload.isTask).toBe(true);
+      expect(payload.taskType).toBe(TaskType.GENERATE_FOLLOW_UP_QUESTIONS);
+    });
+
+    test('should not modify payload for normal messages', () => {
+      const titleDetector = jest.fn().mockReturnValue(false);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+
+      const messages = [{ role: 'user', content: 'Hello, how are you?' }];
+
+      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+
+      expect(payload.isTask).toBe(false);
+      expect(payload.taskType).toBe(null);
+    });
+
+    test('should include all standard fields along with task detection', () => {
+      const titleDetector = jest.fn().mockReturnValue(true);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+
+      const messages = [
+        { role: 'system', content: 'System prompt' },
+        { role: 'user', content: 'Generate a title' },
+      ];
+      const userContext = {
+        userId: 'user-123',
+        userEmail: 'user@example.com',
+        userName: 'John Doe',
+        userRole: 'admin',
+      };
+
+      const payload = n8nClient.buildPayload(messages, 'session-abc', userContext);
+
+      // Standard fields
+      expect(payload.systemPrompt).toBe('System prompt');
+      expect(payload.currentMessage).toBe('Generate a title');
+      expect(payload.chatInput).toBe('Generate a title');
+      expect(payload.messages).toEqual([{ role: 'user', content: 'Generate a title' }]);
+      expect(payload.sessionId).toBe('session-abc');
+      expect(payload.userId).toBe('user-123');
+      expect(payload.userEmail).toBe('user@example.com');
+      expect(payload.userName).toBe('John Doe');
+      expect(payload.userRole).toBe('admin');
+
+      // Task detection fields
+      expect(payload.isTask).toBe(true);
+      expect(payload.taskType).toBe(TaskType.GENERATE_TITLE);
+    });
+
+    test('should handle missing taskDetectorService gracefully', () => {
+      const n8nClientWithoutDetector = new N8nClient(config, null);
+
+      const messages = [{ role: 'user', content: 'Test' }];
+      const payload = n8nClientWithoutDetector.buildPayload(messages, 'session', {
+        userId: 'user',
+      });
+
+      expect(payload.isTask).toBe(false);
+      expect(payload.taskType).toBe(null);
+    });
+  });
+
+  describe('payload structure consistency', () => {
+    test('should always include isTask and taskType fields', () => {
+      config.enableTaskDetection = false;
+      const n8nClientDisabled = new N8nClient(config, null);
+
+      const messages = [{ role: 'user', content: 'Test' }];
+      const payload = n8nClientDisabled.buildPayload(messages, 'session', { userId: 'user' });
+
+      expect(payload).toHaveProperty('isTask');
+      expect(payload).toHaveProperty('taskType');
+      expect(payload.isTask).toBe(false);
+      expect(payload.taskType).toBe(null);
+    });
+
+    test('should maintain consistent payload structure across detection states', () => {
+      const messages = [{ role: 'user', content: 'Test' }];
+      const sessionId = 'session-123';
+      const userContext = { userId: 'user-123' };
+
+      // With detection disabled
+      config.enableTaskDetection = false;
+      const clientDisabled = new N8nClient(config, taskDetectorService);
+      const payloadDisabled = clientDisabled.buildPayload(messages, sessionId, userContext);
+
+      // With detection enabled but no match
+      config.enableTaskDetection = true;
+      const clientEnabled = new N8nClient(config, taskDetectorService);
+      const detector = jest.fn().mockReturnValue(false);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, detector);
+      const payloadEnabled = clientEnabled.buildPayload(messages, sessionId, userContext);
+
+      // Both should have the same structure
+      expect(Object.keys(payloadDisabled).sort()).toEqual(Object.keys(payloadEnabled).sort());
+    });
+  });
+
+  describe('multiple detectors', () => {
+    beforeEach(() => {
+      config.enableTaskDetection = true;
+      n8nClient = new N8nClient(config, taskDetectorService);
+    });
+
+    test('should use first matching detector', () => {
+      const titleDetector = jest.fn().mockReturnValue(false);
+      const tagsDetector = jest.fn().mockReturnValue(true);
+      const followUpDetector = jest.fn().mockReturnValue(true);
+
+      taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TAGS, tagsDetector);
+      taskDetectorService.registerDetector(TaskType.GENERATE_FOLLOW_UP_QUESTIONS, followUpDetector);
+
+      const messages = [{ role: 'user', content: 'Test' }];
+      const payload = n8nClient.buildPayload(messages, 'session', { userId: 'user' });
+
+      expect(payload.isTask).toBe(true);
+      expect(payload.taskType).toBe(TaskType.GENERATE_TAGS);
+    });
+
+    test('should stop at first match and not check remaining detectors', () => {
+      const titleDetector = jest.fn().mockReturnValue(true);
+      const tagsDetector = jest.fn().mockReturnValue(true);
+
+      taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+      taskDetectorService.registerDetector(TaskType.GENERATE_TAGS, tagsDetector);
+
+      const messages = [{ role: 'user', content: 'Test' }];
+      n8nClient.buildPayload(messages, 'session', { userId: 'user' });
+
+      expect(titleDetector).toHaveBeenCalled();
+      // tagsDetector may or may not be called depending on Map iteration order
+      // This is implementation detail, just verify the result is consistent
+    });
+  });
+});

--- a/tests/services/taskDetectorService.test.js
+++ b/tests/services/taskDetectorService.test.js
@@ -1,0 +1,185 @@
+const TaskDetectorService = require('../../src/services/taskDetectorService');
+const TaskType = require('../../src/constants/TaskType');
+
+describe('TaskDetectorService', () => {
+  let service;
+
+  beforeEach(() => {
+    service = new TaskDetectorService();
+  });
+
+  describe('registerDetector', () => {
+    test('should register a detector callback', () => {
+      const mockDetector = jest.fn();
+
+      service.registerDetector(TaskType.GENERATE_TITLE, mockDetector);
+
+      expect(service.detectors.has(TaskType.GENERATE_TITLE)).toBe(true);
+      expect(service.detectors.get(TaskType.GENERATE_TITLE)).toBe(mockDetector);
+    });
+
+    test('should throw error if callback is not a function', () => {
+      expect(() => {
+        service.registerDetector(TaskType.GENERATE_TITLE, 'not-a-function');
+      }).toThrow('Detector callback must be a function');
+    });
+
+    test('should allow overwriting existing detector', () => {
+      const firstDetector = jest.fn();
+      const secondDetector = jest.fn();
+
+      service.registerDetector(TaskType.GENERATE_TITLE, firstDetector);
+      service.registerDetector(TaskType.GENERATE_TITLE, secondDetector);
+
+      expect(service.detectors.get(TaskType.GENERATE_TITLE)).toBe(secondDetector);
+    });
+
+    test('should register multiple detectors for different task types', () => {
+      const titleDetector = jest.fn();
+      const tagsDetector = jest.fn();
+
+      service.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+      service.registerDetector(TaskType.GENERATE_TAGS, tagsDetector);
+
+      expect(service.detectors.size).toBe(2);
+      expect(service.detectors.get(TaskType.GENERATE_TITLE)).toBe(titleDetector);
+      expect(service.detectors.get(TaskType.GENERATE_TAGS)).toBe(tagsDetector);
+    });
+  });
+
+  describe('detectTask', () => {
+    test('should return false when messages array is empty', () => {
+      const result = service.detectTask([]);
+
+      expect(result.isTask).toBe(false);
+      expect(result.taskType).toBe(null);
+    });
+
+    test('should return false when messages is not an array', () => {
+      const result = service.detectTask(null);
+
+      expect(result.isTask).toBe(false);
+      expect(result.taskType).toBe(null);
+    });
+
+    test('should return false when no detectors are registered', () => {
+      const messages = [{ role: 'user', content: 'Hello' }];
+
+      const result = service.detectTask(messages);
+
+      expect(result.isTask).toBe(false);
+      expect(result.taskType).toBe(null);
+    });
+
+    test('should detect task when detector returns true', () => {
+      const mockDetector = jest.fn().mockReturnValue(true);
+      service.registerDetector(TaskType.GENERATE_TITLE, mockDetector);
+
+      const messages = [{ role: 'user', content: 'Generate title' }];
+      const result = service.detectTask(messages);
+
+      expect(result.isTask).toBe(true);
+      expect(result.taskType).toBe(TaskType.GENERATE_TITLE);
+      expect(mockDetector).toHaveBeenCalledWith(messages);
+    });
+
+    test('should return false when detector returns false', () => {
+      const mockDetector = jest.fn().mockReturnValue(false);
+      service.registerDetector(TaskType.GENERATE_TITLE, mockDetector);
+
+      const messages = [{ role: 'user', content: 'Normal message' }];
+      const result = service.detectTask(messages);
+
+      expect(result.isTask).toBe(false);
+      expect(result.taskType).toBe(null);
+      expect(mockDetector).toHaveBeenCalledWith(messages);
+    });
+
+    test('should check detectors in order and return first match', () => {
+      const titleDetector = jest.fn().mockReturnValue(false);
+      const tagsDetector = jest.fn().mockReturnValue(true);
+      const followUpDetector = jest.fn().mockReturnValue(true);
+
+      service.registerDetector(TaskType.GENERATE_TITLE, titleDetector);
+      service.registerDetector(TaskType.GENERATE_TAGS, tagsDetector);
+      service.registerDetector(TaskType.GENERATE_FOLLOW_UP_QUESTIONS, followUpDetector);
+
+      const messages = [{ role: 'user', content: 'Generate tags' }];
+      const result = service.detectTask(messages);
+
+      expect(result.isTask).toBe(true);
+      expect(result.taskType).toBe(TaskType.GENERATE_TAGS);
+      expect(titleDetector).toHaveBeenCalled();
+      expect(tagsDetector).toHaveBeenCalled();
+      // followUpDetector should not be called because tags matched first
+    });
+
+    test('should handle detector errors gracefully', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const errorDetector = jest.fn().mockImplementation(() => {
+        throw new Error('Detector error');
+      });
+      const workingDetector = jest.fn().mockReturnValue(true);
+
+      service.registerDetector(TaskType.GENERATE_TITLE, errorDetector);
+      service.registerDetector(TaskType.GENERATE_TAGS, workingDetector);
+
+      const messages = [{ role: 'user', content: 'Test message' }];
+      const result = service.detectTask(messages);
+
+      expect(result.isTask).toBe(true);
+      expect(result.taskType).toBe(TaskType.GENERATE_TAGS);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Task detector error for generate_title/),
+        'Detector error',
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('should return false when all detectors fail with errors', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const errorDetector = jest.fn().mockImplementation(() => {
+        throw new Error('Detector error');
+      });
+
+      service.registerDetector(TaskType.GENERATE_TITLE, errorDetector);
+
+      const messages = [{ role: 'user', content: 'Test message' }];
+      const result = service.detectTask(messages);
+
+      expect(result.isTask).toBe(false);
+      expect(result.taskType).toBe(null);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('clearDetectors', () => {
+    test('should clear all registered detectors', () => {
+      const detector1 = jest.fn();
+      const detector2 = jest.fn();
+
+      service.registerDetector(TaskType.GENERATE_TITLE, detector1);
+      service.registerDetector(TaskType.GENERATE_TAGS, detector2);
+
+      expect(service.detectors.size).toBe(2);
+
+      service.clearDetectors();
+
+      expect(service.detectors.size).toBe(0);
+    });
+
+    test('should allow re-registering detectors after clearing', () => {
+      const detector1 = jest.fn();
+      const detector2 = jest.fn();
+
+      service.registerDetector(TaskType.GENERATE_TITLE, detector1);
+      service.clearDetectors();
+      service.registerDetector(TaskType.GENERATE_TAGS, detector2);
+
+      expect(service.detectors.size).toBe(1);
+      expect(service.detectors.has(TaskType.GENERATE_TAGS)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements task detection to automatically identify and flag automated generation requests from OpenWebUI and LibreChat clients. The system adds  and  fields to the n8n webhook payload, enabling workflows to route and handle tasks differently from regular conversations.

## Changes

### Core Implementation
- **TaskDetectorService**: Callback-based registry for extensible task detection
- **createDetector**: Generic factory function with pattern group matching
- **detectorRegistry**: Centralized configuration for all client patterns
- **Config**: New  environment variable (default: false)
- **n8nClient**: Payload extended with  and  fields

### Supported Task Types
- `generate_title`: Title generation (OpenWebUI, LibreChat)
- `generate_tags`: Tags generation (OpenWebUI)
- `generate_follow_up_questions`: Follow-up questions (OpenWebUI)

### Testing
- 46 new tests with 100% coverage for task detection components
- All 449 tests passing, overall coverage 94.34%
- Unit tests for TaskDetectorService and createDetector
- Integration tests for n8nClient task detection

### Documentation
- New how-to guide: `docs/howto/TASK_DETECTION.md`
- Practical examples for IF node routing and memory separation
- Configuration guide updated with task detection section
- AGENTS.md quick reference updated

## Use Cases

1. **Route to faster models**: Send task generation to cheaper/faster AI models
2. **Separate memory**: Keep task context separate from conversation memory
3. **Different prompts**: Apply specialized system prompts for tasks
4. **Analytics**: Track automated vs manual interactions

## Breaking Changes

None. Feature is disabled by default and adds fields that are backwards compatible.