### PR TITLE
Fix: Add pagination to package cleanup API call

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -25,9 +25,11 @@ jobs:
         run: |
           echo "Fetching package versions with pr-* tags..."
 
-          # Get all package versions with pr-* tags
+          # Get all package versions with pr-* tags (paginate to get all results)
           VERSIONS=$(gh api /users/${{ github.repository_owner }}/packages/container/n8n-openai-bridge/versions \
-            --jq '[.[] | select(.metadata.container.tags[] | startswith("pr-")) | {id, name, created_at, tags: .metadata.container.tags}]')
+            --paginate \
+            --jq '[.[] | select(.metadata.container.tags[] | startswith("pr-")) | {id, name, created_at, tags: .metadata.container.tags}]' \
+            | jq -s 'add // []')
 
           if [ "$VERSIONS" = "[]" ] || [ -z "$VERSIONS" ]; then
             echo "No PR package versions found."


### PR DESCRIPTION
Fixes the package cleanup workflow to handle repositories with more than 30 package versions by adding pagination support to the GitHub API call.

## Changes
- Add `--paginate` flag to fetch all package versions
- Use `jq -s 'add // []'` to combine paginated JSON arrays into a single result

## Problem
The GitHub API returns a maximum of 30 results per page by default. Without pagination, package versions beyond the first page would not be detected for cleanup.