### PR TITLE
Add: MCP model loader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ BEARER_TOKEN=your-secret-api-key-here
 N8N_WEBHOOK_BEARER_TOKEN=
 
 # Models Configuration
-# MODEL_LOADER_TYPE: "file" (default), "n8n-api", or "static"
+# MODEL_LOADER_TYPE: "file" (default), "n8n-api", "mcp", or "static"
 MODEL_LOADER_TYPE=file
 
 # File Loader Configuration (when MODEL_LOADER_TYPE=file)
@@ -21,6 +21,12 @@ MODELS_CONFIG_FILE=./models.json
 # N8N_API_BEARER_TOKEN=n8n_api_xxxxxxxxxxxxx
 # AUTO_DISCOVERY_TAG=n8n-openai-bridge
 # AUTO_DISCOVERY_POLL_INTERVAL=300
+
+# MCP Loader Configuration (when MODEL_LOADER_TYPE=mcp)
+# Uses n8n's Instance-Level MCP Server for discovery AND execution
+# N8N_MCP_ENDPOINT=http://n8n:5678/mcp-server/http
+# N8N_MCP_BEARER_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+# MCP_POLL_INTERVAL=300  # Polling interval in seconds (60-600, 0=disabled)
 
 # Static Loader Configuration (when MODEL_LOADER_TYPE=static, testing only)
 # STATIC_MODELS={"test-model":"https://n8n.example.com/webhook/test"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ Client → Auth Middleware → Route Handler → n8nClient → n8n Webhook
 **Model Loading System:**
 - `JsonFileModelLoader` (TYPE: `file`) - Default, reads `models.json`, hash-based hot-reload
 - `JsonHttpModelLoader` (TYPE: `json-http`) - Fetches models from HTTP endpoint with polling
-- `N8nApiModelLoader` (TYPE: `n8n-api`) - Auto-discovers tagged workflows via n8n API
+- `N8nApiModelLoader` (TYPE: `n8n-api`) - Auto-discovers tagged workflows via n8n REST API
+- `McpModelLoader` (TYPE: `mcp`) - Discovery AND execution via n8n's Instance-Level MCP Server
 - `StaticModelLoader` (TYPE: `static`) - Testing only, loads from env var
 
 See docs/MODELLOADER.md for details.
@@ -197,12 +198,12 @@ See .github/workflows/README.md for details.
 # Essential
 PORT=3333
 BEARER_TOKEN=your-api-key-here
-MODEL_LOADER_TYPE=file                    # Options: file, json-http, n8n-api, static
+MODEL_LOADER_TYPE=file                    # Options: file, json-http, n8n-api, mcp, static
 MODELS_CONFIG_FILE=./models.json
 ```
 
 See **docs/CONFIGURATION.md** for all environment variables including:
-- Model loading (file, json-http, n8n-api, static loaders)
+- Model loading (file, json-http, n8n-api, mcp, static loaders)
 - Session & user context headers
 - Timeout configuration
 - Webhook notifier

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -100,7 +100,7 @@ Select which loader to use and configure loader-specific variables:
 
 ```bash
 # Loader Selection
-MODEL_LOADER_TYPE=file           # Options: file (default), n8n-api, static
+MODEL_LOADER_TYPE=file           # Options: file (default), n8n-api, json-http, mcp, static
 ```
 
 #### File-based Loader (MODEL_LOADER_TYPE=file)
@@ -132,6 +132,24 @@ AUTO_DISCOVERY_POLL_INTERVAL=300
 | `AUTO_DISCOVERY_POLL_INTERVAL` | No | `300` | Polling interval in seconds (60-600, or 0 to disable) |
 
 For detailed setup, see [Auto-Discovery Loader Documentation](MODELLOADER.md#n8napi-modelloader-type-n8n-api).
+
+#### MCP Loader (MODEL_LOADER_TYPE=mcp)
+
+```bash
+N8N_MCP_ENDPOINT=http://n8n:5678/mcp-server/http
+N8N_MCP_BEARER_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+MCP_POLL_INTERVAL=300
+```
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `N8N_MCP_ENDPOINT` | Yes | - | MCP server endpoint URL |
+| `N8N_MCP_BEARER_TOKEN` | Yes | - | Bearer token for MCP authentication |
+| `MCP_POLL_INTERVAL` | No | `300` | Polling interval in seconds (60-600, or 0 to disable) |
+
+Uses n8n's Instance-Level MCP Server for both discovery and execution. Workflows must be marked "Available in MCP" in n8n settings.
+
+For detailed setup, see [MCP Loader Documentation](MODELLOADER.md#mcpmodelloader-type-mcp).
 
 #### Static Loader (MODEL_LOADER_TYPE=static)
 

--- a/src/Bootstrap.js
+++ b/src/Bootstrap.js
@@ -24,6 +24,8 @@ const WebhookNotifier = require('./services/webhookNotifier');
 const TaskDetectorService = require('./services/taskDetectorService');
 const createDetector = require('./detectors/createDetector');
 const detectorRegistry = require('./detectors/detectorRegistry');
+const McpClient = require('./mcpClient');
+const N8nClient = require('./n8nClient');
 
 /**
  * Bootstrap - Application Lifecycle Orchestrator
@@ -53,6 +55,16 @@ class Bootstrap {
     if (this.config.enableTaskDetection) {
       this.taskDetectorService = new TaskDetectorService();
       this.registerBuiltInDetectors();
+    }
+
+    // Setup execution clients
+    // n8nClient is always available for webhook-based models
+    this.n8nClient = new N8nClient(this.config, this.taskDetectorService);
+
+    // mcpClient is only available when using MCP loader
+    this.mcpClient = null;
+    if (this.modelLoader.constructor.TYPE === 'mcp') {
+      this.mcpClient = new McpClient(this.config.n8nMcpEndpoint, this.config.n8nMcpBearerToken);
     }
 
     // Promise that tracks model loading status

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -67,6 +67,10 @@ class Config {
 
     // File upload configuration
     this.fileUploadMode = this.parseFileUploadMode();
+
+    // MCP configuration (instance-level)
+    this.n8nMcpEndpoint = process.env.N8N_MCP_ENDPOINT || '';
+    this.n8nMcpBearerToken = process.env.N8N_MCP_BEARER_TOKEN || '';
   }
 
   /**

--- a/src/factories/ModelLoaderFactory.js
+++ b/src/factories/ModelLoaderFactory.js
@@ -19,6 +19,7 @@
 const JsonFileModelLoader = require('../loaders/JsonFileModelLoader');
 const N8nApiModelLoader = require('../loaders/N8nApiModelLoader');
 const JsonHttpModelLoader = require('../loaders/JsonHttpModelLoader');
+const McpModelLoader = require('../loaders/McpModelLoader');
 const StaticModelLoader = require('../loaders/StaticModelLoader');
 
 /**
@@ -43,6 +44,7 @@ class ModelLoaderFactory {
     JsonFileModelLoader,
     N8nApiModelLoader,
     JsonHttpModelLoader,
+    McpModelLoader,
     StaticModelLoader,
   ];
 

--- a/src/handlers/mcpNonStreamingHandler.js
+++ b/src/handlers/mcpNonStreamingHandler.js
@@ -1,0 +1,60 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { createCompletionResponse } = require('../utils/openaiResponse');
+
+/**
+ * Handles non-streaming chat completion requests via MCP
+ *
+ * @param {Object} res - Express response object
+ * @param {Object} mcpClient - MCP client instance
+ * @param {string} workflowId - Workflow ID to execute
+ * @param {Array<Object>} messages - Chat messages
+ * @param {string} sessionId - Session identifier
+ * @param {Object} userContext - User context data
+ * @param {string} model - Model identifier
+ * @param {Object} config - Configuration object
+ * @returns {Promise<void>}
+ */
+async function handleMcpNonStreaming(
+  res,
+  mcpClient,
+  workflowId,
+  messages,
+  sessionId,
+  userContext,
+  model,
+  config,
+) {
+  // Extract the last user message as chat input
+  const lastUserMessage = messages.filter((m) => m.role === 'user').pop();
+  const chatInput = lastUserMessage?.content || '';
+
+  // Execute workflow via MCP
+  const content = await mcpClient.executeWorkflow(workflowId, chatInput, sessionId);
+
+  const response = createCompletionResponse(model, content);
+
+  if (config.logRequests) {
+    console.log(`MCP non-streaming completed for session: ${sessionId}`);
+  }
+
+  res.json(response);
+}
+
+module.exports = { handleMcpNonStreaming };

--- a/src/handlers/mcpStreamingHandler.js
+++ b/src/handlers/mcpStreamingHandler.js
@@ -1,0 +1,83 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { createStreamingChunk } = require('../utils/openaiResponse');
+const { createErrorResponse } = require('../utils/errorResponse');
+
+/**
+ * Handles streaming chat completion requests via MCP
+ *
+ * Note: MCP execute_workflow returns the full response at once,
+ * so we simulate streaming by sending the content in a single chunk.
+ *
+ * @param {Object} res - Express response object
+ * @param {Object} mcpClient - MCP client instance
+ * @param {string} workflowId - Workflow ID to execute
+ * @param {Array<Object>} messages - Chat messages
+ * @param {string} sessionId - Session identifier
+ * @param {Object} userContext - User context data
+ * @param {string} model - Model identifier
+ * @param {Object} config - Configuration object
+ * @returns {Promise<void>}
+ */
+async function handleMcpStreaming(
+  res,
+  mcpClient,
+  workflowId,
+  messages,
+  sessionId,
+  userContext,
+  model,
+  config,
+) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  try {
+    // Extract the last user message as chat input
+    const lastUserMessage = messages.filter((m) => m.role === 'user').pop();
+    const chatInput = lastUserMessage?.content || '';
+
+    // Execute workflow via MCP
+    const content = await mcpClient.executeWorkflow(workflowId, chatInput, sessionId);
+
+    // MCP returns full response at once, send as single chunk
+    if (content) {
+      const chunk = createStreamingChunk(model, content, null);
+      res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+    }
+
+    // Send final chunk
+    const finalChunk = createStreamingChunk(model, null, 'stop');
+    res.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
+    res.write('data: [DONE]\n\n');
+    res.end();
+
+    if (config.logRequests) {
+      console.log(`MCP streaming completed for session: ${sessionId}`);
+    }
+  } catch (streamError) {
+    console.error('MCP stream error:', streamError);
+    const errorChunk = createErrorResponse('Error during MCP streaming', 'server_error');
+    res.write(`data: ${JSON.stringify(errorChunk)}\n\n`);
+    res.end();
+  }
+}
+
+module.exports = { handleMcpStreaming };

--- a/src/loaders/McpModelLoader.js
+++ b/src/loaders/McpModelLoader.js
@@ -1,0 +1,328 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const ModelLoader = require('./ModelLoader');
+const McpClient = require('../mcpClient');
+
+/**
+ * Loads models from n8n's Instance-Level MCP Server
+ *
+ * This loader uses n8n's native MCP (Model Context Protocol) server to discover
+ * workflows that are enabled for MCP access. Unlike N8nApiModelLoader which uses
+ * the REST API, this loader communicates via the MCP protocol.
+ *
+ * Key Differences from N8nApiModelLoader:
+ * - Uses MCP protocol instead of REST API
+ * - Discovers workflows enabled via Settings → "Available in MCP"
+ * - Returns extended model format with workflowId for MCP execution
+ * - Uses MCP_POLL_INTERVAL for polling (not AUTO_DISCOVERY_POLL_INTERVAL)
+ *
+ * Model Format:
+ * Unlike other loaders that return string URLs, this loader returns objects:
+ * {
+ *   "model-name": { type: "mcp", workflowId: "abc123" }
+ * }
+ *
+ * Architecture:
+ * 1. Connect to n8n MCP server via Streamable HTTP
+ * 2. Call search_workflows to discover MCP-enabled workflows
+ * 3. Map workflows to extended model format
+ * 4. Optional: Poll for changes at configured interval
+ *
+ * Requirements:
+ * - n8n instance with MCP server enabled
+ * - MCP bearer token (N8N_MCP_BEARER_TOKEN)
+ * - MCP endpoint URL (N8N_MCP_ENDPOINT)
+ * - Workflows must be marked "Available in MCP"
+ */
+class McpModelLoader extends ModelLoader {
+  /**
+   * Loader type identifier for MODEL_LOADER_TYPE env var
+   */
+  static TYPE = 'mcp';
+
+  /**
+   * Get required environment variables for this loader
+   *
+   * Note: N8N_MCP_ENDPOINT and N8N_MCP_BEARER_TOKEN are instance-level
+   * variables validated by Config, not loader-level. This loader only
+   * defines MCP_POLL_INTERVAL as its own configuration.
+   *
+   * @returns {Array<{name: string, description: string, required: boolean, defaultValue?: string}>}
+   */
+  static getRequiredEnvVars() {
+    return [
+      {
+        name: 'N8N_MCP_ENDPOINT',
+        description: 'MCP server endpoint URL (e.g., http://n8n:5678/mcp-server/http)',
+        required: true,
+      },
+      {
+        name: 'N8N_MCP_BEARER_TOKEN',
+        description: 'Bearer token for MCP authentication',
+        required: true,
+      },
+      {
+        name: 'MCP_POLL_INTERVAL',
+        description: 'Polling interval in seconds (60-600, 0=disabled)',
+        required: false,
+        defaultValue: '300',
+      },
+    ];
+  }
+
+  /**
+   * Constructor
+   *
+   * @param {Object} envValues Object with environment variable values
+   */
+  constructor(envValues) {
+    super();
+
+    // Extract values from environment variables
+    const endpoint = envValues.N8N_MCP_ENDPOINT;
+    const bearerToken = envValues.N8N_MCP_BEARER_TOKEN;
+    const pollingIntervalStr = envValues.MCP_POLL_INTERVAL;
+
+    this.endpoint = endpoint;
+    this.bearerToken = bearerToken;
+
+    // Parse polling interval to number
+    const pollingInterval = parseInt(pollingIntervalStr, 10);
+
+    // Validate polling interval (60-600 seconds, or 0 to disable)
+    if (pollingInterval < 0 || isNaN(pollingInterval)) {
+      throw new Error('Polling interval must be >= 0');
+    }
+    if (pollingInterval > 0 && pollingInterval < 60) {
+      console.warn(`Polling interval ${pollingInterval}s is too low, setting to 60s`);
+      this.pollingInterval = 60;
+    } else if (pollingInterval > 600) {
+      console.warn(`Polling interval ${pollingInterval}s is too high, setting to 600s`);
+      this.pollingInterval = 600;
+    } else {
+      this.pollingInterval = pollingInterval;
+    }
+
+    console.log(
+      `McpModelLoader: Using MCP server at ${this.endpoint} (poll: ${this.pollingInterval}s)`,
+    );
+
+    // Create MCP client for discovery
+    this.mcpClient = new McpClient(this.endpoint, this.bearerToken);
+
+    // Polling state
+    this.pollingTimer = null;
+    this.watchCallback = null;
+  }
+
+  /**
+   * Load models from n8n MCP server
+   *
+   * Implementation Flow:
+   * 1. Call search_workflows via MCP
+   * 2. Filter active workflows with chat triggers
+   * 3. Convert to extended model format
+   * 4. Return models object
+   *
+   * @returns {Promise<Object>} Object with model_id -> { type: "mcp", workflowId } mapping
+   * @throws {Error} If MCP request fails
+   */
+  async load() {
+    try {
+      // Search for MCP-enabled workflows
+      const workflows = await this.mcpClient.searchWorkflows();
+
+      console.log(`Fetched ${workflows.length} MCP-enabled workflows`);
+
+      // Convert workflows to models
+      const models = this.workflowsToModels(workflows);
+
+      console.log(`Loaded ${Object.keys(models).length} models from MCP`);
+
+      return models;
+    } catch (error) {
+      // Enhance error message with context
+      throw new Error(`MCP model discovery failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Convert array of workflows to models object
+   *
+   * Model Format:
+   * {
+   *   "workflow-name": { type: "mcp", workflowId: "abc123" }
+   * }
+   *
+   * @param {Array} workflows Array of workflow objects from MCP
+   * @returns {Object} Models object with extended format
+   * @private
+   */
+  workflowsToModels(workflows) {
+    const models = {};
+    const seenIds = new Set();
+
+    for (const workflow of workflows) {
+      // Skip inactive workflows
+      if (!workflow.active) {
+        console.warn(`Skipping inactive workflow: "${workflow.name}" (${workflow.id})`);
+        continue;
+      }
+
+      // Generate model ID from workflow name
+      const modelId = this.generateModelId(workflow);
+
+      // Check for duplicate model IDs
+      if (seenIds.has(modelId)) {
+        console.warn(
+          `Duplicate model ID "${modelId}" detected for workflow "${workflow.name}" (${workflow.id}), skipping`,
+        );
+        continue;
+      }
+
+      seenIds.add(modelId);
+
+      // Store in extended format for MCP execution
+      models[modelId] = {
+        type: 'mcp',
+        workflowId: workflow.id,
+      };
+    }
+
+    return models;
+  }
+
+  /**
+   * Generate model ID from workflow
+   *
+   * Strategy:
+   * 1. Use original workflow name (unsanitized)
+   * 2. Fallback to workflow ID if name is empty
+   *
+   * @param {Object} workflow Workflow object from MCP
+   * @returns {string} Model ID
+   * @private
+   */
+  generateModelId(workflow) {
+    if (workflow.name && workflow.name.trim()) {
+      return workflow.name.trim();
+    }
+    return workflow.id;
+  }
+
+  /**
+   * Validate models - override to handle extended format
+   *
+   * For MCP models, we validate:
+   * - Model ID is non-empty string
+   * - Model value is object with type: "mcp" and workflowId
+   *
+   * @param {Object} models Raw models object
+   * @returns {Object} Validated models (invalid entries filtered)
+   */
+  validateModels(models) {
+    const validated = {};
+
+    for (const [modelId, value] of Object.entries(models)) {
+      // Validate model ID
+      if (!modelId || typeof modelId !== 'string') {
+        console.warn(`Invalid model ID: ${modelId}`);
+        continue;
+      }
+
+      // Validate MCP model format
+      if (!value || typeof value !== 'object') {
+        console.warn(`Invalid model value for "${modelId}": Expected object`);
+        continue;
+      }
+
+      if (value.type !== 'mcp') {
+        console.warn(`Invalid model type for "${modelId}": Expected "mcp"`);
+        continue;
+      }
+
+      if (!value.workflowId || typeof value.workflowId !== 'string') {
+        console.warn(`Invalid workflowId for "${modelId}"`);
+        continue;
+      }
+
+      validated[modelId] = value;
+    }
+
+    return validated;
+  }
+
+  /**
+   * Watch for changes by polling MCP server at configured interval
+   *
+   * @param {Function} callback Function to call when models change
+   */
+  watch(callback) {
+    if (this.pollingInterval === 0) {
+      console.log('Polling disabled (MCP_POLL_INTERVAL=0)');
+      return;
+    }
+
+    if (this.pollingTimer) {
+      console.warn('Polling already active');
+      return;
+    }
+
+    this.watchCallback = callback;
+
+    console.log(`Starting MCP polling every ${this.pollingInterval}s`);
+
+    // Start polling timer
+    this.pollingTimer = setInterval(async () => {
+      console.log('Polling MCP for model changes...');
+      try {
+        const models = await this.load();
+
+        // Calculate hash of current models
+        const currentHash = this.getModelsHash(models);
+
+        // Check if models changed
+        if (currentHash !== this.lastHash) {
+          this.lastHash = currentHash;
+
+          if (this.watchCallback) {
+            this.watchCallback(models);
+          }
+        }
+      } catch (error) {
+        console.error(`MCP polling error: ${error.message}`);
+      }
+    }, this.pollingInterval * 1000);
+  }
+
+  /**
+   * Stop polling for changes
+   */
+  stopWatching() {
+    if (this.pollingTimer) {
+      clearInterval(this.pollingTimer);
+      this.pollingTimer = null;
+      this.watchCallback = null;
+      this.lastHash = null;
+      console.log('Stopped polling MCP server');
+    }
+  }
+}
+
+module.exports = McpModelLoader;

--- a/src/mcpClient.js
+++ b/src/mcpClient.js
@@ -1,0 +1,298 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const axios = require('axios');
+
+/**
+ * McpClient - MCP Protocol Client for n8n Instance-Level MCP Server
+ *
+ * Handles communication with n8n's MCP server using Streamable HTTP transport.
+ * Used for:
+ * - Discovery: search_workflows to find MCP-enabled workflows
+ * - Execution: execute_workflow to run workflows via MCP
+ *
+ * Protocol: JSON-RPC 2.0 over Streamable HTTP (SSE responses)
+ */
+class McpClient {
+  /**
+   * Create McpClient instance
+   * @param {string} endpoint - MCP server endpoint URL
+   * @param {string} bearerToken - Bearer token for authentication
+   * @param {number} [timeout=30000] - Request timeout in milliseconds
+   */
+  constructor(endpoint, bearerToken, timeout = 30000) {
+    this.endpoint = endpoint;
+    this.bearerToken = bearerToken;
+    this.timeout = timeout;
+    this.requestId = 0;
+  }
+
+  /**
+   * Get next JSON-RPC request ID
+   * @returns {number} Unique request ID
+   * @private
+   */
+  getNextRequestId() {
+    return ++this.requestId;
+  }
+
+  /**
+   * Get headers for MCP requests
+   * @returns {Object} HTTP headers
+   * @private
+   */
+  getHeaders() {
+    return {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: `Bearer ${this.bearerToken}`,
+    };
+  }
+
+  /**
+   * Send JSON-RPC request to MCP server
+   * @param {string} method - JSON-RPC method name
+   * @param {Object} params - Method parameters
+   * @returns {Promise<Object>} Parsed response result
+   * @throws {Error} If request fails or returns error
+   * @private
+   */
+  async sendRequest(method, params = {}) {
+    const requestBody = {
+      jsonrpc: '2.0',
+      id: this.getNextRequestId(),
+      method,
+      params,
+    };
+
+    try {
+      const response = await axios.post(this.endpoint, requestBody, {
+        headers: this.getHeaders(),
+        timeout: this.timeout,
+        // Response is SSE, read as text
+        responseType: 'text',
+      });
+
+      return this.parseSSEResponse(response.data);
+    } catch (error) {
+      if (error.response) {
+        const status = error.response.status;
+        if (status === 401) {
+          throw new Error('MCP authentication failed: Invalid bearer token');
+        } else if (status === 403) {
+          throw new Error(`MCP access forbidden: ${this.endpoint}`);
+        } else if (status === 404) {
+          throw new Error(`MCP endpoint not found: ${this.endpoint}`);
+        } else {
+          throw new Error(`MCP request failed (${status}): ${error.message}`);
+        }
+      }
+      throw new Error(`MCP connection error: ${error.message}`);
+    }
+  }
+
+  /**
+   * Parse SSE response from MCP server
+   * @param {string} data - Raw SSE response data
+   * @returns {Object} Parsed JSON-RPC result
+   * @throws {Error} If response contains error or is invalid
+   * @private
+   */
+  parseSSEResponse(data) {
+    // SSE format: "event: message\ndata: {...json...}"
+    const lines = data.split('\n');
+    let jsonData = null;
+
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        jsonData = line.substring(6);
+        break;
+      }
+    }
+
+    if (!jsonData) {
+      throw new Error('Invalid MCP response: No data found in SSE response');
+    }
+
+    try {
+      const parsed = JSON.parse(jsonData);
+
+      // Check for JSON-RPC error
+      if (parsed.error) {
+        throw new Error(`MCP error (${parsed.error.code}): ${parsed.error.message}`);
+      }
+
+      return parsed.result;
+    } catch (error) {
+      if (error.message.startsWith('MCP error')) {
+        throw error;
+      }
+      throw new Error(`Invalid MCP response: Failed to parse JSON - ${error.message}`);
+    }
+  }
+
+  /**
+   * Initialize MCP connection (handshake)
+   * @returns {Promise<Object>} Server capabilities
+   */
+  async initialize() {
+    const result = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: {
+        name: 'n8n-openai-bridge',
+        version: '1.0.0',
+      },
+    });
+
+    return result;
+  }
+
+  /**
+   * Search for MCP-enabled workflows
+   * @param {Object} [options] - Search options
+   * @param {string} [options.query] - Filter by name or description
+   * @param {number} [options.limit] - Max results (1-200)
+   * @returns {Promise<Array>} Array of workflow objects
+   */
+  async searchWorkflows(options = {}) {
+    const result = await this.sendRequest('tools/call', {
+      name: 'search_workflows',
+      arguments: options,
+    });
+
+    // Response contains structuredContent.data array
+    if (result.structuredContent && Array.isArray(result.structuredContent.data)) {
+      return result.structuredContent.data;
+    }
+
+    // Fallback: try content array
+    if (result.content && Array.isArray(result.content)) {
+      const textContent = result.content.find((c) => c.type === 'text');
+      if (textContent) {
+        const parsed = JSON.parse(textContent.text);
+        return parsed.data || [];
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * Get detailed information about a workflow
+   * @param {string} workflowId - Workflow ID
+   * @returns {Promise<Object>} Workflow details
+   */
+  async getWorkflowDetails(workflowId) {
+    const result = await this.sendRequest('tools/call', {
+      name: 'get_workflow_details',
+      arguments: { workflowId },
+    });
+
+    if (result.structuredContent) {
+      return result.structuredContent;
+    }
+
+    // Fallback: try content array
+    if (result.content && Array.isArray(result.content)) {
+      const textContent = result.content.find((c) => c.type === 'text');
+      if (textContent) {
+        return JSON.parse(textContent.text);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Execute a workflow via MCP
+   * @param {string} workflowId - Workflow ID to execute
+   * @param {string} chatInput - Chat message input
+   * @param {string} _sessionId - Session ID for conversation tracking (reserved for future use)
+   * @returns {Promise<string>} Workflow response content
+   */
+  async executeWorkflow(workflowId, chatInput, _sessionId) {
+    const result = await this.sendRequest('tools/call', {
+      name: 'execute_workflow',
+      arguments: {
+        workflowId,
+        inputs: {
+          type: 'chat',
+          chatInput,
+        },
+      },
+    });
+
+    // Extract response from workflow execution result
+    return this.extractWorkflowResponse(result);
+  }
+
+  /**
+   * Extract response content from workflow execution result
+   * @param {Object} result - Raw execution result
+   * @returns {string} Extracted response content
+   * @private
+   */
+  extractWorkflowResponse(result) {
+    // Check structuredContent first
+    const structured = result.structuredContent || result;
+
+    if (!structured.success) {
+      const errorMsg = structured.error || 'Workflow execution failed';
+      throw new Error(`MCP workflow error: ${errorMsg}`);
+    }
+
+    // Navigate to the response in runData
+    // Path: result.runData.<LastNode>[0].data.main[0][0].sendMessage
+    const runData = structured.result?.runData;
+    if (!runData) {
+      throw new Error('MCP workflow error: No runData in response');
+    }
+
+    // Find the last executed node's output
+    const lastNodeName = structured.result?.lastNodeExecuted;
+    if (lastNodeName && runData[lastNodeName]) {
+      const nodeOutput = runData[lastNodeName][0];
+      if (nodeOutput?.data?.main?.[0]?.[0]) {
+        const outputData = nodeOutput.data.main[0][0];
+        // Check common output fields
+        return (
+          outputData.sendMessage ||
+          outputData.text ||
+          outputData.content ||
+          outputData.output ||
+          outputData.json?.content ||
+          outputData.json?.text ||
+          JSON.stringify(outputData.json || outputData)
+        );
+      }
+    }
+
+    // Fallback: try to find any sendMessage in runData
+    for (const nodeName of Object.keys(runData)) {
+      const nodeOutput = runData[nodeName][0];
+      if (nodeOutput?.data?.main?.[0]?.[0]?.sendMessage) {
+        return nodeOutput.data.main[0][0].sendMessage;
+      }
+    }
+
+    throw new Error('MCP workflow error: Could not extract response from workflow');
+  }
+}
+
+module.exports = McpClient;

--- a/src/repositories/ModelRepository.js
+++ b/src/repositories/ModelRepository.js
@@ -43,9 +43,45 @@ class ModelRepository {
    * Get webhook URL for a specific model
    * @param {string} modelId - The model identifier
    * @returns {string|undefined} The webhook URL or undefined if model not found
+   * @deprecated Use getModelInfo() for new code - this method only works for webhook models
    */
   getModelWebhookUrl(modelId) {
-    return this.models[modelId];
+    const value = this.models[modelId];
+    if (typeof value === 'string') {
+      return value;
+    }
+    // For extended format, return url if webhook type
+    if (value && value.type === 'webhook') {
+      return value.url;
+    }
+    return undefined;
+  }
+
+  /**
+   * Get model info with type information
+   * Supports both legacy string format (webhook) and extended object format (mcp)
+   *
+   * @param {string} modelId - The model identifier
+   * @returns {{type: string, url?: string, workflowId?: string}|undefined} Model info or undefined
+   *
+   * @example
+   * // Legacy webhook format (string URL)
+   * getModelInfo("my-model") // → { type: "webhook", url: "https://..." }
+   *
+   * // Extended MCP format (object)
+   * getModelInfo("mcp-model") // → { type: "mcp", workflowId: "abc123" }
+   */
+  getModelInfo(modelId) {
+    const value = this.models[modelId];
+    if (value === undefined) {
+      return undefined;
+    }
+    // Legacy format: string = webhook URL
+    if (typeof value === 'string') {
+      return { type: 'webhook', url: value };
+    }
+    // Extended format: object with type
+    return value;
   }
 
   /**

--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,6 @@
 const express = require('express');
 const cors = require('cors');
 const Bootstrap = require('./Bootstrap');
-const N8nClient = require('./n8nClient');
 const { createErrorResponse } = require('./utils/errorResponse');
 
 // Middleware
@@ -36,13 +35,13 @@ const adminReloadRoute = require('./routes/adminReload');
 
 const app = express();
 const bootstrap = new Bootstrap();
-const n8nClient = new N8nClient(bootstrap.config, bootstrap.taskDetectorService);
 
-// Store bootstrap and n8nClient in app.locals for access in routes
+// Store bootstrap and clients in app.locals for access in routes
 app.locals.bootstrap = bootstrap;
 app.locals.config = bootstrap.config;
 app.locals.modelRepository = bootstrap.modelRepository;
-app.locals.n8nClient = n8nClient;
+app.locals.n8nClient = bootstrap.n8nClient;
+app.locals.mcpClient = bootstrap.mcpClient; // null if not using MCP loader
 
 // Create rate limiters
 const rateLimiters = createRateLimiters(bootstrap.config);

--- a/tests/handlers/mcpNonStreamingHandler.test.js
+++ b/tests/handlers/mcpNonStreamingHandler.test.js
@@ -1,0 +1,182 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { handleMcpNonStreaming } = require('../../src/handlers/mcpNonStreamingHandler');
+
+describe('MCP Non-Streaming Handler', () => {
+  let mockRes;
+  let mockMcpClient;
+  let mockConfig;
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    mockRes = {
+      json: jest.fn(),
+    };
+
+    mockMcpClient = {
+      executeWorkflow: jest.fn(),
+    };
+
+    mockConfig = {
+      logRequests: false,
+    };
+
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  test('should execute workflow and return response', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Hello from MCP');
+
+    await handleMcpNonStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith('workflow-123', 'Hi', 'session-1');
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object: 'chat.completion',
+        model: 'test-model',
+        choices: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.objectContaining({
+              role: 'assistant',
+              content: 'Hello from MCP',
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  test('should extract last user message', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Response');
+
+    const messages = [
+      { role: 'system', content: 'You are helpful' },
+      { role: 'user', content: 'First message' },
+      { role: 'assistant', content: 'First response' },
+      { role: 'user', content: 'Second message' },
+    ];
+
+    await handleMcpNonStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      messages,
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith(
+      'workflow-123',
+      'Second message',
+      'session-1',
+    );
+  });
+
+  test('should handle empty messages', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Response');
+
+    await handleMcpNonStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith('workflow-123', '', 'session-1');
+  });
+
+  test('should handle messages without user role', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Response');
+
+    const messages = [
+      { role: 'system', content: 'You are helpful' },
+      { role: 'assistant', content: 'Hello' },
+    ];
+
+    await handleMcpNonStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      messages,
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith('workflow-123', '', 'session-1');
+  });
+
+  test('should log when logRequests is enabled', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Hello');
+    mockConfig.logRequests = true;
+
+    await handleMcpNonStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'MCP non-streaming completed for session: session-1',
+    );
+  });
+
+  test('should not log when logRequests is disabled', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Hello');
+    mockConfig.logRequests = false;
+
+    await handleMcpNonStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/handlers/mcpStreamingHandler.test.js
+++ b/tests/handlers/mcpStreamingHandler.test.js
@@ -1,0 +1,205 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { handleMcpStreaming } = require('../../src/handlers/mcpStreamingHandler');
+
+describe('MCP Streaming Handler', () => {
+  let mockRes;
+  let mockMcpClient;
+  let mockConfig;
+  let consoleLogSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    mockRes = {
+      setHeader: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn(),
+    };
+
+    mockMcpClient = {
+      executeWorkflow: jest.fn(),
+    };
+
+    mockConfig = {
+      logRequests: false,
+    };
+
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('should set SSE headers', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Hello from MCP');
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
+  });
+
+  test('should execute workflow and stream response', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Hello from MCP');
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith('workflow-123', 'Hi', 'session-1');
+
+    // Should write content chunk, final chunk, and [DONE]
+    expect(mockRes.write).toHaveBeenCalledTimes(3);
+    expect(mockRes.end).toHaveBeenCalled();
+
+    // Check content chunk
+    const contentCall = mockRes.write.mock.calls[0][0];
+    expect(contentCall).toContain('data:');
+    expect(contentCall).toContain('Hello from MCP');
+
+    // Check [DONE]
+    const doneCall = mockRes.write.mock.calls[2][0];
+    expect(doneCall).toBe('data: [DONE]\n\n');
+  });
+
+  test('should extract last user message', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Response');
+
+    const messages = [
+      { role: 'system', content: 'You are helpful' },
+      { role: 'user', content: 'First message' },
+      { role: 'assistant', content: 'First response' },
+      { role: 'user', content: 'Second message' },
+    ];
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      messages,
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith(
+      'workflow-123',
+      'Second message',
+      'session-1',
+    );
+  });
+
+  test('should handle empty messages', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Response');
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(mockMcpClient.executeWorkflow).toHaveBeenCalledWith('workflow-123', '', 'session-1');
+  });
+
+  test('should handle empty response content', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('');
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    // Should only write final chunk and [DONE] (no content chunk for empty string)
+    expect(mockRes.write).toHaveBeenCalledTimes(2);
+    expect(mockRes.end).toHaveBeenCalled();
+  });
+
+  test('should log when logRequests is enabled', async () => {
+    mockMcpClient.executeWorkflow.mockResolvedValue('Hello');
+    mockConfig.logRequests = true;
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('MCP streaming completed for session: session-1');
+  });
+
+  test('should handle errors gracefully', async () => {
+    mockMcpClient.executeWorkflow.mockRejectedValue(new Error('Workflow failed'));
+
+    await handleMcpStreaming(
+      mockRes,
+      mockMcpClient,
+      'workflow-123',
+      [{ role: 'user', content: 'Hi' }],
+      'session-1',
+      {},
+      'test-model',
+      mockConfig,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('MCP stream error:', expect.any(Error));
+
+    // Should write error chunk and end
+    const errorCall = mockRes.write.mock.calls[0][0];
+    expect(errorCall).toContain('data:');
+    expect(errorCall).toContain('error');
+    expect(mockRes.end).toHaveBeenCalled();
+  });
+});

--- a/tests/loaders/McpModelLoader/constructor.test.js
+++ b/tests/loaders/McpModelLoader/constructor.test.js
@@ -1,0 +1,128 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const McpModelLoader = require('../../../src/loaders/McpModelLoader');
+
+jest.mock('../../../src/mcpClient');
+
+describe('McpModelLoader - Constructor', () => {
+  let consoleLogSpy;
+  let consoleWarnSpy;
+
+  beforeAll(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterAll(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should initialize with valid parameters', () => {
+    const loader = new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: '300',
+    });
+
+    expect(loader.endpoint).toBe('http://n8n:5678/mcp-server/http');
+    expect(loader.bearerToken).toBe('test-token');
+    expect(loader.pollingInterval).toBe(300);
+  });
+
+  test('should have correct TYPE identifier', () => {
+    expect(McpModelLoader.TYPE).toBe('mcp');
+  });
+
+  test('should validate polling interval (min 60 seconds)', () => {
+    const loader = new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: '30',
+    });
+
+    expect(loader.pollingInterval).toBe(60);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Polling interval 30s is too low'),
+    );
+  });
+
+  test('should validate polling interval (max 600 seconds)', () => {
+    const loader = new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: '1000',
+    });
+
+    expect(loader.pollingInterval).toBe(600);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Polling interval 1000s is too high'),
+    );
+  });
+
+  test('should allow polling interval of 0 (disabled)', () => {
+    const loader = new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: '0',
+    });
+
+    expect(loader.pollingInterval).toBe(0);
+  });
+
+  test('should throw error for negative polling interval', () => {
+    expect(() => {
+      new McpModelLoader({
+        N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+        N8N_MCP_BEARER_TOKEN: 'test-token',
+        MCP_POLL_INTERVAL: '-10',
+      });
+    }).toThrow('Polling interval must be >= 0');
+  });
+
+  test('should create MCP client instance', () => {
+    const loader = new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: '300',
+    });
+
+    expect(loader.mcpClient).toBeDefined();
+  });
+
+  test('should define required environment variables', () => {
+    const envVars = McpModelLoader.getRequiredEnvVars();
+
+    expect(envVars).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'N8N_MCP_ENDPOINT', required: true }),
+        expect.objectContaining({ name: 'N8N_MCP_BEARER_TOKEN', required: true }),
+        expect.objectContaining({
+          name: 'MCP_POLL_INTERVAL',
+          required: false,
+          defaultValue: '300',
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/loaders/McpModelLoader/load.test.js
+++ b/tests/loaders/McpModelLoader/load.test.js
@@ -1,0 +1,152 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const McpModelLoader = require('../../../src/loaders/McpModelLoader');
+const McpClient = require('../../../src/mcpClient');
+
+jest.mock('../../../src/mcpClient');
+
+describe('McpModelLoader - Load', () => {
+  let consoleLogSpy;
+  let consoleWarnSpy;
+
+  beforeAll(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterAll(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createLoader() {
+    return new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: '300',
+    });
+  }
+
+  test('should load models from MCP server', async () => {
+    const mockWorkflows = [
+      { id: 'workflow-1', name: 'Test Agent', active: true },
+      { id: 'workflow-2', name: 'Another Agent', active: true },
+    ];
+
+    McpClient.prototype.searchWorkflows = jest.fn().mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader();
+    const models = await loader.load();
+
+    expect(models).toEqual({
+      'Test Agent': { type: 'mcp', workflowId: 'workflow-1' },
+      'Another Agent': { type: 'mcp', workflowId: 'workflow-2' },
+    });
+  });
+
+  test('should skip inactive workflows', async () => {
+    const mockWorkflows = [
+      { id: 'workflow-1', name: 'Active Agent', active: true },
+      { id: 'workflow-2', name: 'Inactive Agent', active: false },
+    ];
+
+    McpClient.prototype.searchWorkflows = jest.fn().mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader();
+    const models = await loader.load();
+
+    expect(models).toEqual({
+      'Active Agent': { type: 'mcp', workflowId: 'workflow-1' },
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping inactive workflow'),
+    );
+  });
+
+  test('should use workflow ID as fallback when name is empty', async () => {
+    const mockWorkflows = [
+      { id: 'workflow-1', name: '', active: true },
+      { id: 'workflow-2', name: null, active: true },
+    ];
+
+    McpClient.prototype.searchWorkflows = jest.fn().mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader();
+    const models = await loader.load();
+
+    expect(models).toEqual({
+      'workflow-1': { type: 'mcp', workflowId: 'workflow-1' },
+      'workflow-2': { type: 'mcp', workflowId: 'workflow-2' },
+    });
+  });
+
+  test('should handle duplicate model IDs', async () => {
+    const mockWorkflows = [
+      { id: 'workflow-1', name: 'Duplicate Name', active: true },
+      { id: 'workflow-2', name: 'Duplicate Name', active: true },
+    ];
+
+    McpClient.prototype.searchWorkflows = jest.fn().mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader();
+    const models = await loader.load();
+
+    // First one wins
+    expect(models).toEqual({
+      'Duplicate Name': { type: 'mcp', workflowId: 'workflow-1' },
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate model ID'));
+  });
+
+  test('should handle empty workflow list', async () => {
+    McpClient.prototype.searchWorkflows = jest.fn().mockResolvedValue([]);
+
+    const loader = createLoader();
+    const models = await loader.load();
+
+    expect(models).toEqual({});
+  });
+
+  test('should throw error on MCP failure', async () => {
+    McpClient.prototype.searchWorkflows = jest
+      .fn()
+      .mockRejectedValue(new Error('Connection failed'));
+
+    const loader = createLoader();
+
+    await expect(loader.load()).rejects.toThrow('MCP model discovery failed: Connection failed');
+  });
+
+  test('should trim workflow names', async () => {
+    const mockWorkflows = [{ id: 'workflow-1', name: '  Padded Name  ', active: true }];
+
+    McpClient.prototype.searchWorkflows = jest.fn().mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader();
+    const models = await loader.load();
+
+    expect(models).toEqual({
+      'Padded Name': { type: 'mcp', workflowId: 'workflow-1' },
+    });
+  });
+});

--- a/tests/loaders/McpModelLoader/polling.test.js
+++ b/tests/loaders/McpModelLoader/polling.test.js
@@ -1,0 +1,171 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const McpModelLoader = require('../../../src/loaders/McpModelLoader');
+const McpClient = require('../../../src/mcpClient');
+
+jest.mock('../../../src/mcpClient');
+
+describe('McpModelLoader - Polling', () => {
+  let consoleLogSpy;
+  let consoleWarnSpy;
+  let consoleErrorSpy;
+  let mockSearchWorkflows;
+
+  beforeAll(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+
+    // Setup mock for searchWorkflows before each test
+    mockSearchWorkflows = jest.fn().mockResolvedValue([]);
+    McpClient.mockImplementation(() => ({
+      searchWorkflows: mockSearchWorkflows,
+    }));
+  });
+
+  function createLoader(pollInterval = '60') {
+    return new McpModelLoader({
+      N8N_MCP_ENDPOINT: 'http://n8n:5678/mcp-server/http',
+      N8N_MCP_BEARER_TOKEN: 'test-token',
+      MCP_POLL_INTERVAL: pollInterval,
+    });
+  }
+
+  test('should not start polling when interval is 0', () => {
+    const loader = createLoader('0');
+    const callback = jest.fn();
+
+    loader.watch(callback);
+
+    expect(loader.pollingTimer).toBeNull();
+    expect(consoleLogSpy).toHaveBeenCalledWith('Polling disabled (MCP_POLL_INTERVAL=0)');
+  });
+
+  test('should start polling at configured interval', () => {
+    const loader = createLoader('60');
+    const callback = jest.fn();
+
+    loader.watch(callback);
+
+    expect(loader.pollingTimer).not.toBeNull();
+    expect(consoleLogSpy).toHaveBeenCalledWith('Starting MCP polling every 60s');
+  });
+
+  test('should call callback when models change', async () => {
+    const mockWorkflows = [{ id: 'workflow-1', name: 'Agent', active: true }];
+    mockSearchWorkflows.mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader('60');
+    const callback = jest.fn();
+
+    loader.watch(callback);
+
+    // Advance timer to trigger polling
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(callback).toHaveBeenCalledWith({
+      Agent: { type: 'mcp', workflowId: 'workflow-1' },
+    });
+  });
+
+  test('should not call callback when models have not changed', async () => {
+    const mockWorkflows = [{ id: 'workflow-1', name: 'Agent', active: true }];
+    mockSearchWorkflows.mockResolvedValue(mockWorkflows);
+
+    const loader = createLoader('60');
+    const callback = jest.fn();
+
+    // Set initial hash
+    loader.lastHash = loader.getModelsHash({
+      Agent: { type: 'mcp', workflowId: 'workflow-1' },
+    });
+
+    loader.watch(callback);
+
+    // Advance timer
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('should handle polling errors gracefully', async () => {
+    mockSearchWorkflows.mockRejectedValue(new Error('Network error'));
+
+    const loader = createLoader('60');
+    const callback = jest.fn();
+
+    loader.watch(callback);
+
+    // Advance timer
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'MCP polling error: MCP model discovery failed: Network error',
+    );
+  });
+
+  test('should stop polling when stopWatching is called', () => {
+    const loader = createLoader('60');
+    const callback = jest.fn();
+
+    loader.watch(callback);
+    expect(loader.pollingTimer).not.toBeNull();
+
+    loader.stopWatching();
+
+    expect(loader.pollingTimer).toBeNull();
+    expect(loader.watchCallback).toBeNull();
+    expect(loader.lastHash).toBeNull();
+    expect(consoleLogSpy).toHaveBeenCalledWith('Stopped polling MCP server');
+  });
+
+  test('should warn if watch is called twice', () => {
+    const loader = createLoader('60');
+    const callback = jest.fn();
+
+    loader.watch(callback);
+    loader.watch(callback);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Polling already active');
+  });
+
+  test('should be safe to call stopWatching multiple times', () => {
+    const loader = createLoader('60');
+
+    loader.watch(jest.fn());
+    loader.stopWatching();
+    loader.stopWatching(); // Should not throw
+
+    expect(loader.pollingTimer).toBeNull();
+  });
+});

--- a/tests/mcpClient.test.js
+++ b/tests/mcpClient.test.js
@@ -1,0 +1,402 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const axios = require('axios');
+const McpClient = require('../src/mcpClient');
+
+jest.mock('axios');
+
+describe('McpClient', () => {
+  let client;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new McpClient('http://n8n:5678/mcp-server/http', 'test-token');
+  });
+
+  describe('constructor', () => {
+    test('should initialize with endpoint and token', () => {
+      expect(client.endpoint).toBe('http://n8n:5678/mcp-server/http');
+      expect(client.bearerToken).toBe('test-token');
+      expect(client.timeout).toBe(30000);
+    });
+
+    test('should accept custom timeout', () => {
+      const customClient = new McpClient('http://n8n:5678/mcp-server/http', 'token', 60000);
+      expect(customClient.timeout).toBe(60000);
+    });
+  });
+
+  describe('getHeaders', () => {
+    test('should return correct headers', () => {
+      const headers = client.getHeaders();
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        Authorization: 'Bearer test-token',
+      });
+    });
+  });
+
+  describe('parseSSEResponse', () => {
+    test('should parse valid SSE response', () => {
+      const sseData = 'event: message\ndata: {"result":{"foo":"bar"},"jsonrpc":"2.0","id":1}';
+      const result = client.parseSSEResponse(sseData);
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    test('should throw on missing data line', () => {
+      const sseData = 'event: message\n';
+      expect(() => client.parseSSEResponse(sseData)).toThrow('No data found in SSE response');
+    });
+
+    test('should throw on JSON-RPC error', () => {
+      const sseData =
+        'data: {"error":{"code":-32000,"message":"Test error"},"jsonrpc":"2.0","id":1}';
+      expect(() => client.parseSSEResponse(sseData)).toThrow('MCP error (-32000): Test error');
+    });
+
+    test('should throw on invalid JSON', () => {
+      const sseData = 'data: {invalid json}';
+      expect(() => client.parseSSEResponse(sseData)).toThrow('Failed to parse JSON');
+    });
+  });
+
+  describe('initialize', () => {
+    test('should send initialize request', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"protocolVersion":"2024-11-05","serverInfo":{"name":"n8n MCP Server"}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.initialize();
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://n8n:5678/mcp-server/http',
+        expect.objectContaining({
+          method: 'initialize',
+          params: expect.objectContaining({
+            protocolVersion: '2024-11-05',
+            clientInfo: { name: 'n8n-openai-bridge', version: '1.0.0' },
+          }),
+        }),
+        expect.any(Object),
+      );
+      expect(result).toEqual({
+        protocolVersion: '2024-11-05',
+        serverInfo: { name: 'n8n MCP Server' },
+      });
+    });
+  });
+
+  describe('searchWorkflows', () => {
+    test('should return workflows from structuredContent', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"structuredContent":{"data":[{"id":"wf1","name":"Agent"}],"count":1}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const workflows = await client.searchWorkflows();
+
+      expect(workflows).toEqual([{ id: 'wf1', name: 'Agent' }]);
+    });
+
+    test('should pass query options', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"structuredContent":{"data":[],"count":0}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      await client.searchWorkflows({ query: 'test', limit: 10 });
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          params: {
+            name: 'search_workflows',
+            arguments: { query: 'test', limit: 10 },
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    test('should return empty array when no workflows', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"structuredContent":{"data":[],"count":0}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const workflows = await client.searchWorkflows();
+
+      expect(workflows).toEqual([]);
+    });
+  });
+
+  describe('executeWorkflow', () => {
+    test('should execute workflow and extract response', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"executionId":"1","result":{"lastNodeExecuted":"Respond","runData":{"Respond":[{"data":{"main":[[{"sendMessage":"Hello!"}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hello', 'session-1');
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          params: {
+            name: 'execute_workflow',
+            arguments: {
+              workflowId: 'wf-123',
+              inputs: { type: 'chat', chatInput: 'Hello' },
+            },
+          },
+        }),
+        expect.any(Object),
+      );
+      expect(result).toBe('Hello!');
+    });
+
+    test('should throw on workflow execution failure', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"structuredContent":{"success":false,"error":"Workflow failed"}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      await expect(client.executeWorkflow('wf-123', 'Hello', 'session-1')).rejects.toThrow(
+        'MCP workflow error: Workflow failed',
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    test('should handle 401 authentication error', async () => {
+      axios.post.mockRejectedValue({
+        response: { status: 401 },
+      });
+
+      await expect(client.searchWorkflows()).rejects.toThrow('MCP authentication failed');
+    });
+
+    test('should handle 403 forbidden error', async () => {
+      axios.post.mockRejectedValue({
+        response: { status: 403 },
+      });
+
+      await expect(client.searchWorkflows()).rejects.toThrow('MCP access forbidden');
+    });
+
+    test('should handle 404 not found error', async () => {
+      axios.post.mockRejectedValue({
+        response: { status: 404 },
+      });
+
+      await expect(client.searchWorkflows()).rejects.toThrow('MCP endpoint not found');
+    });
+
+    test('should handle other HTTP errors', async () => {
+      axios.post.mockRejectedValue({
+        response: { status: 500 },
+        message: 'Internal Server Error',
+      });
+
+      await expect(client.searchWorkflows()).rejects.toThrow('MCP request failed (500)');
+    });
+
+    test('should handle network errors', async () => {
+      axios.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(client.searchWorkflows()).rejects.toThrow('MCP connection error');
+    });
+  });
+
+  describe('searchWorkflows - fallback parsing', () => {
+    test('should parse content array fallback', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"content":[{"type":"text","text":"{\\"data\\":[{\\"id\\":\\"wf1\\",\\"name\\":\\"Agent\\"}]}"}]},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const workflows = await client.searchWorkflows();
+
+      expect(workflows).toEqual([{ id: 'wf1', name: 'Agent' }]);
+    });
+
+    test('should return empty array when content has no text type', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"content":[{"type":"image","url":"http://example.com"}]},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const workflows = await client.searchWorkflows();
+
+      expect(workflows).toEqual([]);
+    });
+  });
+
+  describe('getWorkflowDetails', () => {
+    test('should return workflow details from structuredContent', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"structuredContent":{"id":"wf1","name":"Agent","nodes":[]}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const details = await client.getWorkflowDetails('wf1');
+
+      expect(details).toEqual({ id: 'wf1', name: 'Agent', nodes: [] });
+    });
+
+    test('should parse content array fallback', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"content":[{"type":"text","text":"{\\"id\\":\\"wf1\\",\\"name\\":\\"Agent\\"}"}]},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const details = await client.getWorkflowDetails('wf1');
+
+      expect(details).toEqual({ id: 'wf1', name: 'Agent' });
+    });
+
+    test('should return raw result when no structuredContent or content', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"id":"wf1"},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const details = await client.getWorkflowDetails('wf1');
+
+      expect(details).toEqual({ id: 'wf1' });
+    });
+  });
+
+  describe('extractWorkflowResponse', () => {
+    test('should extract sendMessage from last node', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Chat","runData":{"Chat":[{"data":{"main":[[{"sendMessage":"Hello!"}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Hello!');
+    });
+
+    test('should extract text field', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[{"text":"Hello text"}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Hello text');
+    });
+
+    test('should extract content field', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[{"content":"Hello content"}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Hello content');
+    });
+
+    test('should extract output field', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[{"output":"Hello output"}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Hello output');
+    });
+
+    test('should extract json.content field', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[{"json":{"content":"Hello json content"}}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Hello json content');
+    });
+
+    test('should extract json.text field', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[{"json":{"text":"Hello json text"}}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Hello json text');
+    });
+
+    test('should stringify json when no known fields', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[{"json":{"custom":"value"}}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('{"custom":"value"}');
+    });
+
+    test('should fallback to find sendMessage in any node when last node has no output', async () => {
+      // When lastNodeExecuted has no data.main[0][0], it should check other nodes
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"OtherNode","runData":{"OtherNode":[{"data":{"main":[]}}],"ChatNode":[{"data":{"main":[[{"sendMessage":"Found it!"}]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      const result = await client.executeWorkflow('wf-123', 'Hi', 'session-1');
+      expect(result).toBe('Found it!');
+    });
+
+    test('should throw when no runData', async () => {
+      const mockResponse = {
+        data: 'event: message\ndata: {"result":{"structuredContent":{"success":true,"result":{}}},"jsonrpc":"2.0","id":1}',
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      await expect(client.executeWorkflow('wf-123', 'Hi', 'session-1')).rejects.toThrow(
+        'No runData in response',
+      );
+    });
+
+    test('should throw when cannot extract response', async () => {
+      const mockResponse = {
+        data: `event: message
+data: {"result":{"structuredContent":{"success":true,"result":{"lastNodeExecuted":"Node","runData":{"Node":[{"data":{"main":[[]]}}]}}}},"jsonrpc":"2.0","id":1}`,
+      };
+      axios.post.mockResolvedValue(mockResponse);
+
+      await expect(client.executeWorkflow('wf-123', 'Hi', 'session-1')).rejects.toThrow(
+        'Could not extract response from workflow',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds McpModelLoader (TYPE: `mcp`) for n8n's Instance-Level MCP Server.

**What:**
- Discovery via `search_workflows`
- Execution via `execute_workflow` (not webhooks)
- Extended model format: `{ type: 'mcp', workflowId }`

**Config:**
```bash
MODEL_LOADER_TYPE=mcp
N8N_MCP_ENDPOINT=http://n8n:5678/mcp-server/http
N8N_MCP_BEARER_TOKEN=...
```

See docs/MODELLOADER.md for details.