### PR TITLE
Add: in-memory OpenAI Files API (/v1/files)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,11 @@ USER_ROLE_HEADERS=X-User-Role,X-OpenWebUI-User-Role
 #   extract-json: Extract files to separate 'files' array with clean base64 data
 #   extract-multipart: Recommended - send as multipart/form-data, works out of the box with n8n
 #   disabled: Strip all file content, forward text only
+
+# Files API Configuration (In-Memory OpenAI Files Endpoint)
+# Simulates the OpenAI /v1/files endpoint with in-memory storage
+# FILES_ENABLED=true                   # Enable/disable Files API (default: true)
+# FILES_MAX_FILE_SIZE=20971520         # Max size per file in bytes (default: 20MB)
+# FILES_MAX_TOTAL_STORAGE=209715200    # Max total in-memory storage in bytes (default: 200MB)
+# FILES_TTL_SECONDS=3600              # File expiration time in seconds (default: 1 hour)
+# FILES_CLEANUP_INTERVAL_SECONDS=60   # Cleanup sweep interval in seconds (default: 60)

--- a/.env.example
+++ b/.env.example
@@ -86,5 +86,6 @@ USER_ROLE_HEADERS=X-User-Role,X-OpenWebUI-User-Role
 # FILES_ENABLED=true                   # Enable/disable Files API (default: true)
 # FILES_MAX_FILE_SIZE=20971520         # Max size per file in bytes (default: 20MB)
 # FILES_MAX_TOTAL_STORAGE=209715200    # Max total in-memory storage in bytes (default: 200MB)
+# FILES_MAX_COUNT=1000                # Max number of stored files (default: 1000)
 # FILES_TTL_SECONDS=3600              # File expiration time in seconds (default: 1 hour)
 # FILES_CLEANUP_INTERVAL_SECONDS=60   # Cleanup sweep interval in seconds (default: 60)

--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,4 @@ USER_ROLE_HEADERS=X-User-Role,X-OpenWebUI-User-Role
 # FILES_MAX_COUNT=1000                # Max number of stored files (default: 1000)
 # FILES_TTL_SECONDS=3600              # File expiration time in seconds (default: 1 hour)
 # FILES_CLEANUP_INTERVAL_SECONDS=60   # Cleanup sweep interval in seconds (default: 60)
+# FILES_LIST_ENABLED=false            # Enable GET /v1/files listing (default: false)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,12 @@ n8n-openai-bridge/
 │   ├── Bootstrap.js       # Application lifecycle orchestration
 │   ├── n8nClient.js       # n8n webhook client
 │   ├── config/            # Configuration (ENV, server settings)
-│   ├── repositories/      # Data repositories (model state)
+│   ├── repositories/      # Data repositories (model state, file storage)
 │   ├── factories/         # Factory classes (loaders, notifiers)
-│   ├── routes/            # API endpoints (health, models, chat, admin)
+│   ├── routes/            # API endpoints (health, models, chat, files, admin)
 │   ├── handlers/          # Request handlers (streaming, non-streaming)
 │   ├── middleware/        # Express middleware (auth, logging, rate limiting)
-│   ├── services/          # Business logic (session, user, validation)
+│   ├── services/          # Business logic (files, tasks, webhooks)
 │   ├── loaders/           # Model loader architecture (file, json-http, n8n-api, static)
 │   ├── notifiers/         # Webhook notifiers (model changes)
 │   └── utils/             # Utility functions
@@ -69,6 +69,9 @@ Client → Auth Middleware → Route Handler → n8nClient → n8n Webhook
 - `server.js` - Express setup, OpenAI endpoints
 - `n8nClient.js` - n8n webhook communication
 - `taskDetectorService.js` - Detects automated task generation requests (optional)
+- `FileRepository.js` - In-memory file storage with TTL
+- `fileService.js` - File upload, retrieval, expiration logic
+- `fileResolver.js` - Resolves file_id references to inline content in chat completions
 
 **Model Loading System:**
 - `JsonFileModelLoader` (TYPE: `file`) - Default, reads `models.json`, hash-based hot-reload
@@ -127,7 +130,7 @@ Never run `npm install` on host machine.
 - One class per file, file name matches class name
 - Lowercase directories (services/, loaders/, utils/)
 - Tests mirror src/ structure (src/utils/session.js → tests/utils/session.test.js)
-- `src/services/` → Classes with state/dependencies (e.g., `TaskDetectorService`, `WebhookNotifier`)
+- `src/services/` → Classes with state/dependencies (e.g., `TaskDetectorService`, `WebhookNotifierService`, `FileService`)
 - `src/utils/` → Stateless pure functions (e.g., `sessionExtractor.js`, `userExtractor.js`, `requestValidator.js`)
 
 ### Copyright Headers
@@ -207,6 +210,7 @@ See **docs/CONFIGURATION.md** for all environment variables including:
 - Timeout configuration
 - Webhook notifier
 - Task detection
+- Files API (in-memory OpenAI `/v1/files` endpoint)
 
 ## Common Issues
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ OpenAI-compatible API middleware for n8n workflows. Use your n8n agents and work
 - Session tracking for conversation memory
 - User context forwarding (ID, email, name, role)
 - File uploads support (images, documents)
+- In-memory OpenAI Files API (`/v1/files`) with TTL-based expiration
 - Rate limiting with configurable thresholds per endpoint
 - Request ID tracking for distributed tracing
 - Docker ready with health checks
@@ -44,6 +45,7 @@ See [Integration Guide](docs/INTEGRATIONS.md) for setup.
    └────────────────────┬────────────────────────┘
                         │ OpenAI API Format
                         │ /v1/chat/completions
+                        │ /v1/files
                         ▼
               ┌─────────────────────┐
               │ n8n OpenAI Bridge   │
@@ -198,7 +200,8 @@ n8n-openai-bridge/
 │   ├── config/            # Configuration
 │   │   └── Config.js      # ENV parsing & server settings
 │   ├── repositories/      # Data repositories
-│   │   └── ModelRepository.js  # Model state management
+│   │   ├── ModelRepository.js  # Model state management
+│   │   └── FileRepository.js   # In-memory file storage
 │   ├── factories/         # Factory classes
 │   │   ├── ModelLoaderFactory.js     # Create model loaders
 │   │   └── WebhookNotifierFactory.js # Create webhook notifiers

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -392,7 +392,7 @@ FILE_UPLOAD_MODE=passthrough         # Options: passthrough, extract-json, extra
 
 **Supported file types:**
 - Images: PNG, JPEG, GIF, WebP, SVG
-- Documents: PDF, Word (DOC/DOCX), Excel (XLS/XLSX), CSV, plain text, JSON
+- Documents: PDF, Word (DOC/DOCX), Excel (XLS/XLSX), PowerPoint (PPT/PPTX), CSV, plain text, JSON
 
 ### Files API (In-Memory)
 
@@ -405,6 +405,7 @@ FILES_MAX_FILE_SIZE=20971520           # Max size per file in bytes (default: 20
 FILES_MAX_TOTAL_STORAGE=209715200      # Max total in-memory storage in bytes (default: 200MB)
 FILES_TTL_SECONDS=3600                 # File expiration time in seconds (default: 1 hour)
 FILES_CLEANUP_INTERVAL_SECONDS=60      # Cleanup sweep interval in seconds (default: 60)
+FILES_LIST_ENABLED=false               # Enable GET /v1/files listing (default: false)
 ```
 
 | Variable | Default | Description |
@@ -414,6 +415,7 @@ FILES_CLEANUP_INTERVAL_SECONDS=60      # Cleanup sweep interval in seconds (defa
 | `FILES_MAX_TOTAL_STORAGE` | `209715200` (200MB) | Maximum total in-memory storage for all files. |
 | `FILES_TTL_SECONDS` | `3600` (1 hour) | Time-to-live for stored files before automatic eviction. |
 | `FILES_CLEANUP_INTERVAL_SECONDS` | `60` | How often the cleanup sweep runs to remove expired files. |
+| `FILES_LIST_ENABLED` | `false` | Enable the `GET /v1/files` list endpoint. Disabled by default to prevent users from listing files uploaded by others. |
 
 **Endpoints:**
 - `POST /v1/files` - Upload a file (multipart/form-data)
@@ -432,6 +434,9 @@ FILES_CLEANUP_INTERVAL_SECONDS=60      # Cleanup sweep interval in seconds (defa
 - Files are stored entirely in memory - plan `FILES_MAX_TOTAL_STORAGE` according to available RAM
 - Expired files are lazily evicted on access and periodically by the cleanup sweep
 - The Files API requires authentication (same `BEARER_TOKEN` as other endpoints)
+
+**Limitations:**
+- Files are not scoped per user. Since all clients share the same bearer token, any authenticated user could access files uploaded by others if they know the file ID (UUID). The `GET /v1/files` list endpoint is disabled by default (`FILES_LIST_ENABLED=false`) to prevent users from browsing files uploaded by others. Enable it only in single-user or trusted environments.
 
 ### Rate Limiting
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -392,7 +392,46 @@ FILE_UPLOAD_MODE=passthrough         # Options: passthrough, extract-json, extra
 
 **Supported file types:**
 - Images: PNG, JPEG, GIF, WebP, SVG
-- Documents: PDF, plain text, JSON
+- Documents: PDF, Word (DOC/DOCX), Excel (XLS/XLSX), CSV, plain text, JSON
+
+### Files API (In-Memory)
+
+The bridge implements the OpenAI `/v1/files` endpoint with in-memory storage. This allows clients like Open WebUI to upload files (PDFs, documents) which are then resolved into inline content when referenced in chat completions.
+
+```bash
+# Files API Configuration
+FILES_ENABLED=true                     # Enable/disable Files API (default: true)
+FILES_MAX_FILE_SIZE=20971520           # Max size per file in bytes (default: 20MB)
+FILES_MAX_TOTAL_STORAGE=209715200      # Max total in-memory storage in bytes (default: 200MB)
+FILES_TTL_SECONDS=3600                 # File expiration time in seconds (default: 1 hour)
+FILES_CLEANUP_INTERVAL_SECONDS=60      # Cleanup sweep interval in seconds (default: 60)
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FILES_ENABLED` | `true` | Enable/disable the `/v1/files` endpoints. Set to `false` to disable entirely. |
+| `FILES_MAX_FILE_SIZE` | `20971520` (20MB) | Maximum size per uploaded file in bytes. |
+| `FILES_MAX_TOTAL_STORAGE` | `209715200` (200MB) | Maximum total in-memory storage for all files. |
+| `FILES_TTL_SECONDS` | `3600` (1 hour) | Time-to-live for stored files before automatic eviction. |
+| `FILES_CLEANUP_INTERVAL_SECONDS` | `60` | How often the cleanup sweep runs to remove expired files. |
+
+**Endpoints:**
+- `POST /v1/files` - Upload a file (multipart/form-data)
+- `GET /v1/files` - List uploaded files
+- `GET /v1/files/:file_id` - Get file metadata
+- `GET /v1/files/:file_id/content` - Download file content
+- `DELETE /v1/files/:file_id` - Delete a file
+
+**How it works:**
+1. Client uploads a file via `POST /v1/files`, receives a `file-{uuid}` ID
+2. Client references the file ID in a chat completion request (via attachments or content parts)
+3. The bridge resolves file references to inline base64 data URLs before forwarding to n8n
+4. Files are automatically cleaned up after `FILES_TTL_SECONDS`
+
+**Notes:**
+- Files are stored entirely in memory - plan `FILES_MAX_TOTAL_STORAGE` according to available RAM
+- Expired files are lazily evicted on access and periodically by the cleanup sweep
+- The Files API requires authentication (same `BEARER_TOKEN` as other endpoints)
 
 ### Rate Limiting
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -41,6 +41,8 @@ tags:
     description: Model management endpoints
   - name: Chat
     description: Chat completion endpoints
+  - name: Files
+    description: In-memory OpenAI Files API with TTL-based expiration
   - name: Admin
     description: Administrative endpoints
 
@@ -184,6 +186,171 @@ paths:
           $ref: '#/components/responses/ModelNotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+
+  /v1/files:
+    post:
+      summary: Upload a file
+      description: Upload a file to in-memory storage. Files are stored with a TTL and automatically expired.
+      operationId: uploadFile
+      tags:
+        - Files
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - purpose
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The file to upload
+                purpose:
+                  type: string
+                  enum: [assistants, batch, fine-tune, vision, user_data, evals]
+                  description: The intended purpose of the file
+      responses:
+        '200':
+          description: File uploaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileObject'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '413':
+          description: File too large or storage limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    get:
+      summary: List files
+      description: List uploaded files with optional filtering and pagination.
+      operationId: listFiles
+      tags:
+        - Files
+      parameters:
+        - name: purpose
+          in: query
+          schema:
+            type: string
+          description: Filter by purpose
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            default: 10000
+          description: Maximum number of results
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort order by created_at
+        - name: after
+          in: query
+          schema:
+            type: string
+          description: Cursor for pagination (file ID)
+      responses:
+        '200':
+          description: List of files
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  object:
+                    type: string
+                    example: list
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FileObject'
+                  has_more:
+                    type: boolean
+
+  /v1/files/{file_id}:
+    get:
+      summary: Retrieve file metadata
+      operationId: getFile
+      tags:
+        - Files
+      parameters:
+        - name: file_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: File metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileObject'
+        '404':
+          $ref: '#/components/responses/ValidationError'
+    delete:
+      summary: Delete a file
+      operationId: deleteFile
+      tags:
+        - Files
+      parameters:
+        - name: file_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: File deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  object:
+                    type: string
+                    example: file
+                  deleted:
+                    type: boolean
+                    example: true
+        '404':
+          $ref: '#/components/responses/ValidationError'
+
+  /v1/files/{file_id}/content:
+    get:
+      summary: Retrieve file content
+      description: Returns the raw binary content of the file.
+      operationId: getFileContent
+      tags:
+        - Files
+      parameters:
+        - name: file_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: File content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          $ref: '#/components/responses/ValidationError'
 
   /admin/reload:
     post:
@@ -357,6 +524,38 @@ components:
             total_tokens:
               type: integer
               example: 30
+
+    FileObject:
+      type: object
+      properties:
+        id:
+          type: string
+          description: File identifier
+          example: file-abc123
+        object:
+          type: string
+          enum: [file]
+        bytes:
+          type: integer
+          description: File size in bytes
+          example: 120000
+        created_at:
+          type: integer
+          description: Unix timestamp of creation
+          example: 1677610602
+        filename:
+          type: string
+          example: document.pdf
+        purpose:
+          type: string
+          enum: [assistants, batch, fine-tune, vision, user_data, evals]
+        status:
+          type: string
+          enum: [processed]
+        expires_at:
+          type: integer
+          description: Unix timestamp when the file expires
+          example: 1677614202
 
     Error:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1781,13 +1781,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2365,13 +2365,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2724,9 +2724,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4144,12 +4144,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
-      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -4326,9 +4326,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4587,9 +4587,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4597,13 +4597,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4865,9 +4865,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5598,9 +5598,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5870,9 +5870,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6062,9 +6062,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6544,9 +6544,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6776,9 +6776,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6870,9 +6870,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6880,9 +6880,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7882,9 +7882,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8195,9 +8195,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8205,6 +8205,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^5.1.0",
         "express-rate-limit": "^8.1.0",
         "form-data": "^4.0.5",
+        "multer": "^2.1.1",
         "uuid": "^11.0.0"
       },
       "devDependencies": {
@@ -2272,6 +2273,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -2823,7 +2830,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/buildcheck": {
@@ -2834,6 +2840,17 @@
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/byline": {
@@ -3168,6 +3185,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -6064,6 +6110,47 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nan": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
@@ -7253,6 +7340,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -7269,7 +7364,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7759,6 +7853,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7887,7 +7987,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^8.1.0",
     "form-data": "^4.0.5",
+    "multer": "^2.1.1",
     "uuid": "^11.0.0"
   },
   "devDependencies": {

--- a/src/Bootstrap.js
+++ b/src/Bootstrap.js
@@ -18,9 +18,11 @@
 
 const Config = require('./config/Config');
 const ModelRepository = require('./repositories/ModelRepository');
+const FileRepository = require('./repositories/FileRepository');
 const ModelLoaderFactory = require('./factories/ModelLoaderFactory');
 const WebhookNotifierFactory = require('./factories/WebhookNotifierFactory');
-const WebhookNotifier = require('./services/webhookNotifier');
+const WebhookNotifierService = require('./services/webhookNotifierService');
+const FileService = require('./services/fileService');
 const TaskDetectorService = require('./services/taskDetectorService');
 const createDetector = require('./detectors/createDetector');
 const detectorRegistry = require('./detectors/detectorRegistry');
@@ -47,6 +49,14 @@ class Bootstrap {
     this.modelRepository = new ModelRepository();
     this.modelLoader = ModelLoaderFactory.createModelLoader();
     this.webhookNotifier = WebhookNotifierFactory.createWebhookNotifier();
+
+    // Setup file service if enabled
+    this.fileRepository = null;
+    this.fileService = null;
+    if (this.config.filesEnabled) {
+      this.fileRepository = new FileRepository();
+      this.fileService = new FileService(this.fileRepository, this.config);
+    }
 
     // Setup task detector if enabled
     this.taskDetectorService = null;
@@ -93,10 +103,10 @@ class Bootstrap {
 
         // Notify webhook on startup if enabled
         if (this.webhookNotifier.enabled && this.webhookNotifier.notifyOnStartup) {
-          const payload = WebhookNotifier.createPayload(
+          const payload = WebhookNotifierService.createPayload(
             models,
             this.modelLoader.constructor.name,
-            WebhookNotifier.EventType.MODELS_LOADED,
+            WebhookNotifierService.EventType.MODELS_LOADED,
           );
           this.webhookNotifier.notify(payload).catch(() => {
             console.warn(
@@ -117,6 +127,11 @@ class Bootstrap {
 
     // Setup model watcher after initial load
     this.setupModelWatcher();
+
+    // Start file cleanup interval if enabled
+    if (this.fileService) {
+      this.fileService.startCleanupInterval();
+    }
   }
 
   /**
@@ -131,10 +146,10 @@ class Bootstrap {
       console.log(`Models reloaded successfully (${this.modelRepository.getModelCount()} models)`);
 
       // Notify webhook subscribers about model changes
-      const payload = WebhookNotifier.createPayload(
+      const payload = WebhookNotifierService.createPayload(
         newModels,
         this.modelLoader.constructor.name,
-        WebhookNotifier.EventType.MODELS_CHANGED,
+        WebhookNotifierService.EventType.MODELS_CHANGED,
       );
       this.webhookNotifier.notify(payload).catch(() => {
         console.warn(
@@ -151,6 +166,12 @@ class Bootstrap {
   close() {
     if (this.modelLoader) {
       this.modelLoader.stopWatching();
+    }
+    if (this.fileService) {
+      this.fileService.stopCleanupInterval();
+    }
+    if (this.fileRepository) {
+      this.fileRepository.clear();
     }
   }
 }

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -75,6 +75,7 @@ class Config {
     this.filesMaxCount = this.parseIntFromEnv('FILES_MAX_COUNT', 1000);
     this.filesTtlSeconds = this.parseIntFromEnv('FILES_TTL_SECONDS', 3600);
     this.filesCleanupIntervalSeconds = this.parseIntFromEnv('FILES_CLEANUP_INTERVAL_SECONDS', 60);
+    this.filesListEnabled = process.env.FILES_LIST_ENABLED === 'true';
 
     // Streaming configuration
     const sep = process.env.AGENT_TURN_SEPARATOR;

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -52,10 +52,10 @@ class Config {
     this.userRoleHeaders = this.parseUserRoleHeaders();
 
     // Timeout configuration
-    this.n8nTimeout = this.parseTimeout('N8N_TIMEOUT', 300000);
-    this.serverTimeout = this.parseTimeout('SERVER_TIMEOUT', 300000);
-    this.serverKeepAliveTimeout = this.parseTimeout('SERVER_KEEP_ALIVE_TIMEOUT', 120000);
-    this.serverHeadersTimeout = this.parseTimeout('SERVER_HEADERS_TIMEOUT', 121000);
+    this.n8nTimeout = this.parseIntFromEnv('N8N_TIMEOUT', 300000, 1000);
+    this.serverTimeout = this.parseIntFromEnv('SERVER_TIMEOUT', 300000, 1000);
+    this.serverKeepAliveTimeout = this.parseIntFromEnv('SERVER_KEEP_ALIVE_TIMEOUT', 120000, 1000);
+    this.serverHeadersTimeout = this.parseIntFromEnv('SERVER_HEADERS_TIMEOUT', 121000, 1000);
 
     // Validate headers timeout > keep-alive timeout
     if (this.serverHeadersTimeout <= this.serverKeepAliveTimeout) {
@@ -67,6 +67,13 @@ class Config {
 
     // File upload configuration
     this.fileUploadMode = this.parseFileUploadMode();
+
+    // Files API configuration (in-memory OpenAI Files endpoint)
+    this.filesEnabled = process.env.FILES_ENABLED !== 'false';
+    this.filesMaxFileSize = this.parseIntFromEnv('FILES_MAX_FILE_SIZE', 20 * 1024 * 1024);
+    this.filesMaxTotalStorage = this.parseIntFromEnv('FILES_MAX_TOTAL_STORAGE', 200 * 1024 * 1024);
+    this.filesTtlSeconds = this.parseIntFromEnv('FILES_TTL_SECONDS', 3600);
+    this.filesCleanupIntervalSeconds = this.parseIntFromEnv('FILES_CLEANUP_INTERVAL_SECONDS', 60);
 
     // Streaming configuration
     const sep = process.env.AGENT_TURN_SEPARATOR;
@@ -188,13 +195,14 @@ class Config {
   }
 
   /**
-   * Parse timeout value from environment variable
+   * Parse an integer from environment variable with minimum threshold
    * @param {string} envVarName - Name of the environment variable
-   * @param {number} defaultValue - Default timeout in milliseconds
-   * @returns {number} Timeout in milliseconds
+   * @param {number} defaultValue - Default value if env var not set or invalid
+   * @param {number} [min=1] - Minimum accepted value
+   * @returns {number} Parsed integer
    * @private
    */
-  parseTimeout(envVarName, defaultValue) {
+  parseIntFromEnv(envVarName, defaultValue, min = 1) {
     const envValue = process.env[envVarName];
 
     if (!envValue || !envValue.trim()) {
@@ -203,8 +211,8 @@ class Config {
 
     const parsed = parseInt(envValue, 10);
 
-    if (isNaN(parsed) || parsed < 1000) {
-      console.warn(`${envVarName} must be a number >= 1000ms. Using default: ${defaultValue}ms.`);
+    if (isNaN(parsed) || parsed < min) {
+      console.warn(`${envVarName} must be a number >= ${min}. Using default: ${defaultValue}.`);
       return defaultValue;
     }
 

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -72,6 +72,7 @@ class Config {
     this.filesEnabled = process.env.FILES_ENABLED !== 'false';
     this.filesMaxFileSize = this.parseIntFromEnv('FILES_MAX_FILE_SIZE', 20 * 1024 * 1024);
     this.filesMaxTotalStorage = this.parseIntFromEnv('FILES_MAX_TOTAL_STORAGE', 200 * 1024 * 1024);
+    this.filesMaxCount = this.parseIntFromEnv('FILES_MAX_COUNT', 1000);
     this.filesTtlSeconds = this.parseIntFromEnv('FILES_TTL_SECONDS', 3600);
     this.filesCleanupIntervalSeconds = this.parseIntFromEnv('FILES_CLEANUP_INTERVAL_SECONDS', 60);
 

--- a/src/factories/WebhookNotifierFactory.js
+++ b/src/factories/WebhookNotifierFactory.js
@@ -16,13 +16,13 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-const WebhookNotifier = require('../services/webhookNotifier');
+const WebhookNotifierService = require('../services/webhookNotifierService');
 
 /**
- * WebhookNotifierFactory - Factory for creating WebhookNotifier instances
+ * WebhookNotifierFactory - Factory for creating WebhookNotifierService instances
  *
  * Responsibilities:
- * - Create and configure WebhookNotifier instances
+ * - Create and configure WebhookNotifierService instances
  * - Read webhook-related environment variables
  *
  * Does NOT:
@@ -32,9 +32,9 @@ const WebhookNotifier = require('../services/webhookNotifier');
  */
 class WebhookNotifierFactory {
   /**
-   * Create and configure the WebhookNotifier
+   * Create and configure the WebhookNotifierService
    * Only enabled if WEBHOOK_NOTIFIER_URL is set
-   * @returns {WebhookNotifier} Configured notifier instance
+   * @returns {WebhookNotifierService} Configured notifier instance
    */
   static createWebhookNotifier() {
     const config = {
@@ -45,7 +45,7 @@ class WebhookNotifierFactory {
       notifyOnStartup: process.env.WEBHOOK_NOTIFIER_ON_STARTUP === 'true',
     };
 
-    return new WebhookNotifier(config);
+    return new WebhookNotifierService(config);
   }
 }
 

--- a/src/repositories/FileRepository.js
+++ b/src/repositories/FileRepository.js
@@ -1,0 +1,148 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * FileRepository - In-Memory File Storage
+ *
+ * Responsibilities:
+ * - Store and retrieve file metadata and binary data
+ * - Track total storage usage
+ * - Provide listing with filtering and pagination
+ *
+ * Does NOT:
+ * - Validate files or enforce limits (see FileService)
+ * - Handle expiration logic (see FileService)
+ * - Parse configuration (see Config)
+ */
+class FileRepository {
+  constructor() {
+    /** @type {Map<string, {metadata: Object, buffer: Buffer}>} */
+    this.files = new Map();
+
+    /** @type {number} */
+    this.totalBytes = 0;
+  }
+
+  /**
+   * Store a file entry
+   * @param {string} fileId - The file identifier
+   * @param {Object} entry - The file entry
+   * @param {Object} entry.metadata - OpenAI file object metadata (includes expires_at)
+   * @param {Buffer} entry.buffer - Raw file content
+   */
+  store(fileId, entry) {
+    const existing = this.files.get(fileId);
+    if (existing) {
+      this.totalBytes -= existing.metadata.bytes;
+    }
+    this.files.set(fileId, entry);
+    this.totalBytes += entry.metadata.bytes;
+  }
+
+  /**
+   * Get a file entry by ID
+   * @param {string} fileId - The file identifier
+   * @returns {{metadata: Object, buffer: Buffer}|undefined}
+   */
+  get(fileId) {
+    return this.files.get(fileId);
+  }
+
+  /**
+   * Delete a file by ID
+   * @param {string} fileId - The file identifier
+   * @returns {boolean} True if file was deleted
+   */
+  delete(fileId) {
+    const entry = this.files.get(fileId);
+    if (!entry) {
+      return false;
+    }
+    this.totalBytes -= entry.metadata.bytes;
+    this.files.delete(fileId);
+    return true;
+  }
+
+  /**
+   * List files with optional filtering and pagination
+   * @param {Object} [options={}]
+   * @param {string} [options.purpose] - Filter by purpose
+   * @param {number} [options.limit=10000] - Max results
+   * @param {string} [options.order='desc'] - Sort order by created_at ('asc' or 'desc')
+   * @param {string} [options.after] - Cursor: return files after this ID
+   * @returns {Array<Object>} Array of file metadata objects
+   */
+  list({ purpose, limit = 10000, order = 'desc', after } = {}) {
+    let entries = Array.from(this.files.values()).map((entry) => entry.metadata);
+
+    // Filter by purpose
+    if (purpose) {
+      entries = entries.filter((m) => m.purpose === purpose);
+    }
+
+    // Sort by created_at
+    entries.sort((a, b) =>
+      order === 'asc' ? a.created_at - b.created_at : b.created_at - a.created_at,
+    );
+
+    // Pagination: skip entries until after cursor
+    if (after) {
+      const idx = entries.findIndex((m) => m.id === after);
+      if (idx !== -1) {
+        entries = entries.slice(idx + 1);
+      }
+    }
+
+    // Apply limit
+    return entries.slice(0, limit);
+  }
+
+  /**
+   * Get all file entries (for cleanup iteration)
+   * @returns {Map<string, {metadata: Object, buffer: Buffer}>}
+   */
+  getAll() {
+    return this.files;
+  }
+
+  /**
+   * Get current total storage in bytes
+   * @returns {number}
+   */
+  getTotalBytes() {
+    return this.totalBytes;
+  }
+
+  /**
+   * Get number of stored files
+   * @returns {number}
+   */
+  getCount() {
+    return this.files.size;
+  }
+
+  /**
+   * Remove all files
+   */
+  clear() {
+    this.files.clear();
+    this.totalBytes = 0;
+  }
+}
+
+module.exports = FileRepository;

--- a/src/routes/chatCompletions.js
+++ b/src/routes/chatCompletions.js
@@ -25,6 +25,7 @@ const { createErrorResponse } = require('../utils/errorResponse');
 const { debugSessionDetection } = require('../utils/debugSession');
 const { handleStreaming } = require('../handlers/streamingHandler');
 const { handleNonStreaming } = require('../handlers/nonStreamingHandler');
+const { resolveFileReferences } = require('../utils/fileResolver');
 
 const router = express.Router();
 
@@ -108,13 +109,17 @@ router.post('/', async (req, res) => {
     console.log(`Stream: ${stream}`);
   }
 
+  // Resolve file_id references to inline content
+  const fileService = req.app.locals.fileService;
+  const resolvedMessages = fileService ? resolveFileReferences(messages, fileService) : messages;
+
   try {
     if (stream) {
       await handleStreaming(
         res,
         n8nClient,
         webhookUrl,
-        messages,
+        resolvedMessages,
         sessionId,
         userContext,
         model,
@@ -125,7 +130,7 @@ router.post('/', async (req, res) => {
         res,
         n8nClient,
         webhookUrl,
-        messages,
+        resolvedMessages,
         sessionId,
         userContext,
         model,

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -111,6 +111,12 @@ router.post(
  * List files with optional filtering
  */
 router.get('/', (req, res) => {
+  const config = req.app.locals.config;
+
+  if (!config.filesListEnabled) {
+    return res.status(200).json({ object: 'list', data: [], has_more: false });
+  }
+
   const fileService = req.app.locals.fileService;
 
   try {

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -97,6 +97,9 @@ router.post(
       if (error.code === 'STORAGE_LIMIT_EXCEEDED') {
         return sendError(res, 413, error.message, 'invalid_request_error');
       }
+      if (error.code === 'FILE_COUNT_LIMIT_EXCEEDED') {
+        return sendError(res, 413, error.message, 'invalid_request_error');
+      }
       console.error(`[${new Date().toISOString()}] Error uploading file: ${error.message}`);
       sendError(res, 500, 'Internal server error', 'server_error');
     }

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -1,0 +1,178 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const express = require('express');
+const multer = require('multer');
+const { sendError } = require('../utils/errorResponse');
+const FileService = require('../services/fileService');
+const { getMimeTypeFromFilename } = require('../utils/mimeTypes');
+
+const router = express.Router();
+
+let cachedUpload = null;
+
+/**
+ * Get or create multer upload middleware configured from app config
+ * @param {Object} config - Application config
+ * @returns {Object} Multer upload instance
+ */
+function getUpload(config) {
+  if (!cachedUpload) {
+    cachedUpload = multer({
+      storage: multer.memoryStorage(),
+      limits: { fileSize: config.filesMaxFileSize },
+    });
+  }
+  return cachedUpload;
+}
+
+/**
+ * POST /v1/files
+ * Upload a file (multipart/form-data)
+ */
+router.post(
+  '/',
+  (req, res, next) => {
+    const config = req.app.locals.config;
+    const upload = getUpload(config);
+
+    upload.single('file')(req, res, (err) => {
+      if (err) {
+        if (err.code === 'LIMIT_FILE_SIZE') {
+          return sendError(
+            res,
+            413,
+            'File size exceeds maximum allowed size',
+            'invalid_request_error',
+          );
+        }
+        return sendError(res, 400, err.message, 'invalid_request_error');
+      }
+      next();
+    });
+  },
+  (req, res) => {
+    const fileService = req.app.locals.fileService;
+
+    if (!req.file) {
+      return sendError(res, 400, 'Missing required parameter: file', 'invalid_request_error');
+    }
+
+    const purpose = req.body.purpose;
+    if (!purpose) {
+      return sendError(res, 400, 'Missing required parameter: purpose', 'invalid_request_error');
+    }
+
+    if (!FileService.isValidPurpose(purpose)) {
+      return sendError(
+        res,
+        400,
+        `Invalid purpose. Valid purposes: ${FileService.VALID_PURPOSES.join(', ')}`,
+        'invalid_request_error',
+      );
+    }
+
+    try {
+      const metadata = fileService.upload(req.file.originalname, purpose, req.file.buffer);
+      res.status(200).json(metadata);
+    } catch (error) {
+      if (error.code === 'FILE_TOO_LARGE') {
+        return sendError(res, 413, error.message, 'invalid_request_error');
+      }
+      if (error.code === 'STORAGE_LIMIT_EXCEEDED') {
+        return sendError(res, 413, error.message, 'invalid_request_error');
+      }
+      console.error(`[${new Date().toISOString()}] Error uploading file: ${error.message}`);
+      sendError(res, 500, 'Internal server error', 'server_error');
+    }
+  },
+);
+
+/**
+ * GET /v1/files
+ * List files with optional filtering
+ */
+router.get('/', (req, res) => {
+  const fileService = req.app.locals.fileService;
+
+  try {
+    const result = fileService.listFiles({
+      purpose: req.query.purpose,
+      limit: req.query.limit,
+      order: req.query.order,
+      after: req.query.after,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    console.error(`[${new Date().toISOString()}] Error listing files: ${error.message}`);
+    sendError(res, 500, 'Internal server error', 'server_error');
+  }
+});
+
+/**
+ * GET /v1/files/:file_id
+ * Retrieve file metadata
+ */
+router.get('/:file_id', (req, res) => {
+  const fileService = req.app.locals.fileService;
+  const fileId = req.params.file_id;
+
+  const metadata = fileService.getFile(fileId);
+  if (!metadata) {
+    return sendError(res, 404, `File '${fileId}' not found`, 'invalid_request_error');
+  }
+
+  res.status(200).json(metadata);
+});
+
+/**
+ * DELETE /v1/files/:file_id
+ * Delete a file
+ */
+router.delete('/:file_id', (req, res) => {
+  const fileService = req.app.locals.fileService;
+  const fileId = req.params.file_id;
+
+  const result = fileService.deleteFile(fileId);
+  if (!result) {
+    return sendError(res, 404, `File '${fileId}' not found`, 'invalid_request_error');
+  }
+
+  res.status(200).json(result);
+});
+
+/**
+ * GET /v1/files/:file_id/content
+ * Retrieve file binary content
+ */
+router.get('/:file_id/content', (req, res) => {
+  const fileService = req.app.locals.fileService;
+  const fileId = req.params.file_id;
+
+  const fileContent = fileService.getFileContent(fileId);
+  if (!fileContent) {
+    return sendError(res, 404, `File '${fileId}' not found`, 'invalid_request_error');
+  }
+
+  const mimeType = getMimeTypeFromFilename(fileContent.metadata.filename);
+  res.set('Content-Type', mimeType);
+  res.set('Content-Disposition', `attachment; filename="${fileContent.metadata.filename}"`);
+  res.send(fileContent.buffer);
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -32,6 +32,7 @@ const createRateLimiters = require('./middleware/rateLimiter');
 const healthRoute = require('./routes/health');
 const modelsRoute = require('./routes/models');
 const chatCompletionsRoute = require('./routes/chatCompletions');
+const filesRoute = require('./routes/files');
 const adminReloadRoute = require('./routes/adminReload');
 
 const app = express();
@@ -43,6 +44,7 @@ app.locals.bootstrap = bootstrap;
 app.locals.config = bootstrap.config;
 app.locals.modelRepository = bootstrap.modelRepository;
 app.locals.n8nClient = n8nClient;
+app.locals.fileService = bootstrap.fileService;
 
 // Create rate limiters
 const rateLimiters = createRateLimiters(bootstrap.config);
@@ -67,6 +69,9 @@ app.use(authenticate(bootstrap.config));
 app.use('/admin/reload', rateLimiters.standard, adminReloadRoute);
 app.use('/v1/models', rateLimiters.standard, modelsRoute);
 app.use('/v1/chat/completions', rateLimiters.chatCompletions, chatCompletionsRoute);
+if (bootstrap.config.filesEnabled) {
+  app.use('/v1/files', rateLimiters.standard, filesRoute);
+}
 
 // Error handler
 app.use((err, _req, res, _next) => {
@@ -134,6 +139,13 @@ async function startServer() {
     console.log('  GET  /health');
     console.log('  GET  /v1/models');
     console.log('  POST /v1/chat/completions');
+    if (bootstrap.config.filesEnabled) {
+      console.log('  POST /v1/files');
+      console.log('  GET  /v1/files');
+      console.log('  GET  /v1/files/:file_id');
+      console.log('  GET  /v1/files/:file_id/content');
+      console.log('  DEL  /v1/files/:file_id');
+    }
     console.log('  POST /admin/reload');
     console.log('='.repeat(60));
   });

--- a/src/services/fileService.js
+++ b/src/services/fileService.js
@@ -1,0 +1,255 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * FileService - Business Logic for In-Memory File Operations
+ *
+ * Responsibilities:
+ * - Validate file uploads (size, storage limits)
+ * - Generate file IDs and metadata
+ * - Manage TTL-based file expiration
+ * - Provide file query operations
+ *
+ * Does NOT:
+ * - Handle HTTP requests (see routes/files.js)
+ * - Store files directly (see FileRepository)
+ * - Parse configuration (see Config)
+ */
+class FileService {
+  /**
+   * Valid purpose values for file uploads
+   * @type {string[]}
+   */
+  static VALID_PURPOSES = ['assistants', 'batch', 'fine-tune', 'vision', 'user_data', 'evals'];
+
+  /**
+   * @param {import('../repositories/FileRepository')} fileRepository
+   * @param {import('../config/Config')} config
+   */
+  constructor(fileRepository, config) {
+    this.fileRepository = fileRepository;
+    this.config = config;
+    this.cleanupTimer = null;
+  }
+
+  /**
+   * Upload a file to in-memory storage
+   * @param {string} filename - Original filename
+   * @param {string} purpose - File purpose (e.g., 'assistants', 'vision')
+   * @param {Buffer} buffer - File content
+   * @returns {Object} OpenAI file object
+   * @throws {Error} If file exceeds size limit or storage is full
+   */
+  upload(filename, purpose, buffer) {
+    const bytes = buffer.length;
+
+    if (bytes > this.config.filesMaxFileSize) {
+      const error = new Error(
+        `File size ${bytes} bytes exceeds maximum of ${this.config.filesMaxFileSize} bytes`,
+      );
+      error.code = 'FILE_TOO_LARGE';
+      throw error;
+    }
+
+    if (this.fileRepository.getTotalBytes() + bytes > this.config.filesMaxTotalStorage) {
+      const error = new Error('Total file storage limit exceeded');
+      error.code = 'STORAGE_LIMIT_EXCEEDED';
+      throw error;
+    }
+
+    const fileId = FileService.generateFileId();
+    const now = Math.floor(Date.now() / 1000);
+
+    const metadata = {
+      id: fileId,
+      object: 'file',
+      bytes,
+      created_at: now,
+      filename,
+      purpose,
+      status: 'processed',
+      expires_at: now + this.config.filesTtlSeconds,
+    };
+
+    this.fileRepository.store(fileId, {
+      metadata,
+      buffer,
+    });
+
+    return metadata;
+  }
+
+  /**
+   * Get file metadata by ID
+   * @param {string} fileId - The file identifier
+   * @returns {Object|null} File metadata or null if not found
+   */
+  getFile(fileId) {
+    const entry = this.fileRepository.get(fileId);
+    if (!entry) {
+      return null;
+    }
+    if (FileService.isExpired(entry)) {
+      this.fileRepository.delete(fileId);
+      return null;
+    }
+    return entry.metadata;
+  }
+
+  /**
+   * Get file binary content by ID
+   * @param {string} fileId - The file identifier
+   * @returns {{buffer: Buffer, metadata: Object}|null} File content and metadata, or null
+   */
+  getFileContent(fileId) {
+    const entry = this.fileRepository.get(fileId);
+    if (!entry) {
+      return null;
+    }
+    if (FileService.isExpired(entry)) {
+      this.fileRepository.delete(fileId);
+      return null;
+    }
+    return { buffer: entry.buffer, metadata: entry.metadata };
+  }
+
+  /**
+   * Delete a file by ID
+   * @param {string} fileId - The file identifier
+   * @returns {Object|null} Deletion confirmation or null if not found
+   */
+  deleteFile(fileId) {
+    const deleted = this.fileRepository.delete(fileId);
+    if (!deleted) {
+      return null;
+    }
+    return {
+      id: fileId,
+      object: 'file',
+      deleted: true,
+    };
+  }
+
+  /**
+   * List files with optional filtering
+   * @param {Object} [options] - Filtering options
+   * @returns {{data: Array<Object>, has_more: boolean}} Paginated file list
+   */
+  listFiles(options = {}) {
+    const limit = Math.min(Math.max(parseInt(options.limit) || 10000, 1), 10000);
+    const data = this.fileRepository.list({
+      purpose: options.purpose,
+      limit: limit + 1,
+      order: options.order || 'desc',
+      after: options.after,
+    });
+
+    const hasMore = data.length > limit;
+    return {
+      object: 'list',
+      data: data.slice(0, limit),
+      has_more: hasMore,
+    };
+  }
+
+  /**
+   * Remove expired files from storage
+   * @returns {number} Number of files cleaned up
+   */
+  cleanup() {
+    const now = Math.floor(Date.now() / 1000);
+    const expiredIds = [];
+
+    for (const [fileId, entry] of this.fileRepository.getAll()) {
+      if (entry.metadata.expires_at <= now) {
+        expiredIds.push(fileId);
+      }
+    }
+
+    for (const fileId of expiredIds) {
+      this.fileRepository.delete(fileId);
+    }
+
+    const cleaned = expiredIds.length;
+
+    if (cleaned > 0) {
+      console.log(
+        `[${new Date().toISOString()}] File cleanup: removed ${cleaned} expired file(s), ${this.fileRepository.getCount()} remaining`,
+      );
+    }
+
+    return cleaned;
+  }
+
+  /**
+   * Start periodic cleanup interval
+   */
+  startCleanupInterval() {
+    if (this.cleanupTimer) {
+      return;
+    }
+    this.cleanupTimer = setInterval(
+      () => this.cleanup(),
+      this.config.filesCleanupIntervalSeconds * 1000,
+    );
+    // Allow process to exit even if timer is active
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  /**
+   * Stop periodic cleanup interval
+   */
+  stopCleanupInterval() {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  /**
+   * Generate a unique file ID
+   * @returns {string} File ID in format "file-{uuid}"
+   */
+  static generateFileId() {
+    return `file-${uuidv4()}`;
+  }
+
+  /**
+   * Check if a purpose value is valid
+   * @param {string} purpose
+   * @returns {boolean}
+   */
+  static isValidPurpose(purpose) {
+    return FileService.VALID_PURPOSES.includes(purpose);
+  }
+
+  /**
+   * Check if a file entry has expired
+   * @param {{metadata: {expires_at: number}}} entry
+   * @returns {boolean}
+   */
+  static isExpired(entry) {
+    return entry.metadata.expires_at <= Math.floor(Date.now() / 1000);
+  }
+}
+
+module.exports = FileService;

--- a/src/services/fileService.js
+++ b/src/services/fileService.js
@@ -74,15 +74,24 @@ class FileService {
       throw error;
     }
 
+    if (this.fileRepository.getCount() >= this.config.filesMaxCount) {
+      const error = new Error(
+        `File count limit of ${this.config.filesMaxCount} reached. Delete existing files or wait for expiration.`,
+      );
+      error.code = 'FILE_COUNT_LIMIT_EXCEEDED';
+      throw error;
+    }
+
     const fileId = FileService.generateFileId();
     const now = Math.floor(Date.now() / 1000);
+    const sanitized = FileService.sanitizeFilename(filename);
 
     const metadata = {
       id: fileId,
       object: 'file',
       bytes,
       created_at: now,
-      filename,
+      filename: sanitized,
       purpose,
       status: 'processed',
       expires_at: now + this.config.filesTtlSeconds,
@@ -249,6 +258,43 @@ class FileService {
    */
   static isExpired(entry) {
     return entry.metadata.expires_at <= Math.floor(Date.now() / 1000);
+  }
+
+  /** @type {number} Max allowed filename length */
+  static MAX_FILENAME_LENGTH = 255;
+
+  /**
+   * Sanitize a filename for safe storage and HTTP header use.
+   * Strips path components, control characters, and Content-Disposition-unsafe characters.
+   * @param {string} filename - Raw filename from client
+   * @returns {string} Sanitized filename
+   */
+  static sanitizeFilename(filename) {
+    if (!filename || typeof filename !== 'string') {
+      return 'unnamed';
+    }
+
+    let sanitized = filename
+      .replace(/^.*[/\\]/, '') // strip directory components
+      .replace(/[\x00-\x1f\x7f]/g, '') // remove control characters
+      .replace(/["\\]/g, '_') // replace chars unsafe in Content-Disposition
+      .trim();
+
+    if (sanitized.length > FileService.MAX_FILENAME_LENGTH) {
+      const dotIndex = sanitized.lastIndexOf('.');
+      if (dotIndex > 0) {
+        const ext = sanitized.slice(dotIndex);
+        sanitized = sanitized.slice(0, FileService.MAX_FILENAME_LENGTH - ext.length) + ext;
+      } else {
+        sanitized = sanitized.slice(0, FileService.MAX_FILENAME_LENGTH);
+      }
+    }
+
+    if (!sanitized || sanitized === '.') {
+      return 'unnamed';
+    }
+
+    return sanitized;
   }
 }
 

--- a/src/services/webhookNotifierService.js
+++ b/src/services/webhookNotifierService.js
@@ -29,7 +29,7 @@ const WebhookEventType = {
 /**
  * Service for notifying external webhooks when models change
  */
-class WebhookNotifier {
+class WebhookNotifierService {
   static EventType = WebhookEventType;
   constructor(config = {}) {
     this.webhookUrl = config.webhookUrl || null;
@@ -45,7 +45,7 @@ class WebhookNotifier {
   /**
    * Notify webhook about model changes
    * @param {Object} payload - Notification payload
-   * @param {WebhookEventType} payload.type - Event type (WebhookNotifier.EventType.MODELS_CHANGED or .MODELS_LOADED)
+   * @param {WebhookEventType} payload.type - Event type (WebhookNotifierService.EventType.MODELS_CHANGED or .MODELS_LOADED)
    * @param {Object} payload.models - Updated models object
    * @param {string} payload.source - Source of the change (loader class name)
    * @param {string} payload.timestamp - ISO timestamp of the change
@@ -117,13 +117,13 @@ class WebhookNotifier {
    * Create payload for model change notification
    * @param {Object} models - Models object
    * @param {string} source - Source loader class name
-   * @param {WebhookEventType} eventType - Event type (use WebhookNotifier.EventType enum, required)
+   * @param {WebhookEventType} eventType - Event type (use WebhookNotifierService.EventType enum, required)
    * @returns {Object} Notification payload
    */
   static createPayload(models, source, eventType) {
     if (!eventType) {
       throw new Error(
-        'eventType is required. Use WebhookNotifier.EventType.MODELS_CHANGED or .MODELS_LOADED',
+        'eventType is required. Use WebhookNotifierService.EventType.MODELS_CHANGED or .MODELS_LOADED',
       );
     }
 
@@ -137,4 +137,4 @@ class WebhookNotifier {
   }
 }
 
-module.exports = WebhookNotifier;
+module.exports = WebhookNotifierService;

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -56,26 +56,7 @@ function parseDataUrl(dataUrl) {
   };
 }
 
-/**
- * Get file extension from mime type
- * @param {string} mimeType - MIME type (e.g., "image/png")
- * @returns {string} File extension (e.g., "png")
- */
-function getExtensionFromMimeType(mimeType) {
-  const mimeToExt = {
-    'image/png': 'png',
-    'image/jpeg': 'jpg',
-    'image/jpg': 'jpg',
-    'image/gif': 'gif',
-    'image/webp': 'webp',
-    'image/svg+xml': 'svg',
-    'application/pdf': 'pdf',
-    'text/plain': 'txt',
-    'application/json': 'json',
-  };
-
-  return mimeToExt[mimeType] || 'bin';
-}
+const { getExtensionFromMimeType } = require('./mimeTypes');
 
 /**
  * Extract text content from a multimodal message

--- a/src/utils/fileResolver.js
+++ b/src/utils/fileResolver.js
@@ -1,0 +1,164 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Resolve file_id references in chat completion messages to inline base64 data URLs.
+ *
+ * Handles two reference patterns:
+ * 1. Attachments array: message.attachments[].file_id -> injected as image_url content parts
+ * 2. Content parts: image_url.url starting with "file-" -> replaced with data URL
+ *
+ * @param {Array<Object>} messages - OpenAI chat messages
+ * @param {import('../services/fileService')} fileService - FileService instance
+ * @returns {Array<Object>} Messages with file references resolved to data URLs
+ */
+function resolveFileReferences(messages, fileService) {
+  if (!messages || !Array.isArray(messages)) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    let resolved = message;
+
+    // Pattern 1: Attachments array with file_id entries
+    if (Array.isArray(message.attachments) && message.attachments.length > 0) {
+      resolved = resolveAttachments(resolved, fileService);
+    }
+
+    // Pattern 2: Content parts with file-prefixed URLs
+    if (Array.isArray(resolved.content)) {
+      resolved = resolveContentParts(resolved, fileService);
+    }
+
+    return resolved;
+  });
+}
+
+/**
+ * Resolve attachments array by converting file_id references to inline content parts
+ * @param {Object} message - Chat message with attachments
+ * @param {import('../services/fileService')} fileService
+ * @returns {Object} Message with attachments resolved into content parts
+ */
+function resolveAttachments(message, fileService) {
+  const fileParts = [];
+
+  for (const attachment of message.attachments) {
+    if (!attachment.file_id) {
+      continue;
+    }
+
+    const fileContent = fileService.getFileContent(attachment.file_id);
+    if (!fileContent) {
+      console.warn(
+        `[${new Date().toISOString()}] File reference '${attachment.file_id}' not found (expired or never uploaded), skipping`,
+      );
+      continue;
+    }
+
+    const dataUrl = bufferToDataUrl(fileContent.buffer, fileContent.metadata.filename);
+    fileParts.push({
+      type: 'image_url',
+      image_url: { url: dataUrl },
+    });
+  }
+
+  if (fileParts.length === 0) {
+    return message;
+  }
+
+  // Convert string content to array format if needed
+  let contentParts;
+  if (typeof message.content === 'string') {
+    contentParts = message.content ? [{ type: 'text', text: message.content }] : [];
+  } else if (Array.isArray(message.content)) {
+    contentParts = [...message.content];
+  } else {
+    contentParts = [];
+  }
+
+  // Append file parts and remove attachments key
+  const { attachments: _attachments, ...rest } = message;
+  return {
+    ...rest,
+    content: [...contentParts, ...fileParts],
+  };
+}
+
+/**
+ * Resolve content parts where image_url.url starts with "file-"
+ * @param {Object} message - Chat message with content array
+ * @param {import('../services/fileService')} fileService
+ * @returns {Object} Message with file references replaced by data URLs
+ */
+function resolveContentParts(message, fileService) {
+  let changed = false;
+
+  const resolvedContent = message.content.map((part) => {
+    if (part.type !== 'image_url' || !part.image_url?.url) {
+      return part;
+    }
+
+    const url = part.image_url.url;
+    if (!url.startsWith('file-')) {
+      return part;
+    }
+
+    const fileContent = fileService.getFileContent(url);
+    if (!fileContent) {
+      console.warn(
+        `[${new Date().toISOString()}] File reference '${url}' not found (expired or never uploaded), skipping`,
+      );
+      return part;
+    }
+
+    changed = true;
+    const dataUrl = bufferToDataUrl(fileContent.buffer, fileContent.metadata.filename);
+    return {
+      ...part,
+      image_url: { ...part.image_url, url: dataUrl },
+    };
+  });
+
+  if (!changed) {
+    return message;
+  }
+
+  return { ...message, content: resolvedContent };
+}
+
+const { getMimeTypeFromFilename } = require('./mimeTypes');
+
+/**
+ * Convert a buffer to a base64 data URL
+ * @param {Buffer} buffer - File content
+ * @param {string} filename - Original filename (used for mime type detection)
+ * @returns {string} Data URL (e.g., "data:image/png;base64,...")
+ */
+function bufferToDataUrl(buffer, filename) {
+  const mimeType = getMimeTypeFromFilename(filename);
+  const base64 = buffer.toString('base64');
+  return `data:${mimeType};base64,${base64}`;
+}
+
+module.exports = {
+  resolveFileReferences,
+  resolveAttachments,
+  resolveContentParts,
+  bufferToDataUrl,
+};

--- a/src/utils/mimeTypes.js
+++ b/src/utils/mimeTypes.js
@@ -1,0 +1,74 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Shared MIME type <-> file extension mappings
+ */
+
+const MIME_TO_EXT = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'application/pdf': 'pdf',
+  'text/plain': 'txt',
+  'application/json': 'json',
+  'application/msword': 'doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'application/vnd.ms-excel': 'xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'text/csv': 'csv',
+};
+
+// Build reverse map (ext -> mime), skip duplicate extensions (first wins)
+const EXT_TO_MIME = {};
+for (const [mime, ext] of Object.entries(MIME_TO_EXT)) {
+  if (!EXT_TO_MIME[ext]) {
+    EXT_TO_MIME[ext] = mime;
+  }
+}
+// Add jpeg alias explicitly (MIME_TO_EXT maps both image/jpeg and image/jpg to 'jpg')
+EXT_TO_MIME['jpeg'] = 'image/jpeg';
+
+/**
+ * Get file extension from MIME type
+ * @param {string} mimeType - MIME type (e.g., "image/png")
+ * @returns {string} File extension (e.g., "png"), or "bin" if unknown
+ */
+function getExtensionFromMimeType(mimeType) {
+  return MIME_TO_EXT[mimeType] || 'bin';
+}
+
+/**
+ * Get MIME type from filename extension
+ * @param {string} filename - Filename (e.g., "doc.pdf")
+ * @returns {string} MIME type, or "application/octet-stream" if unknown
+ */
+function getMimeTypeFromFilename(filename) {
+  const ext = (filename || '').split('.').pop().toLowerCase();
+  return EXT_TO_MIME[ext] || 'application/octet-stream';
+}
+
+module.exports = {
+  MIME_TO_EXT,
+  EXT_TO_MIME,
+  getExtensionFromMimeType,
+  getMimeTypeFromFilename,
+};

--- a/src/utils/mimeTypes.js
+++ b/src/utils/mimeTypes.js
@@ -35,6 +35,8 @@ const MIME_TO_EXT = {
   'application/vnd.ms-excel': 'xls',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
   'text/csv': 'csv',
+  'application/vnd.ms-powerpoint': 'ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
 };
 
 // Build reverse map (ext -> mime), skip duplicate extensions (first wins)

--- a/tests/config/config.files.test.js
+++ b/tests/config/config.files.test.js
@@ -1,0 +1,126 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+describe('Config - Files API', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function loadConfig() {
+    return new (require('../../src/config/Config'))();
+  }
+
+  describe('filesEnabled', () => {
+    it('should default to true', () => {
+      delete process.env.FILES_ENABLED;
+      const config = loadConfig();
+      expect(config.filesEnabled).toBe(true);
+    });
+
+    it('should be false when set to false', () => {
+      process.env.FILES_ENABLED = 'false';
+      const config = loadConfig();
+      expect(config.filesEnabled).toBe(false);
+    });
+
+    it('should be true for any value other than false', () => {
+      process.env.FILES_ENABLED = 'true';
+      const config = loadConfig();
+      expect(config.filesEnabled).toBe(true);
+    });
+  });
+
+  describe('filesMaxFileSize', () => {
+    it('should default to 20MB', () => {
+      delete process.env.FILES_MAX_FILE_SIZE;
+      const config = loadConfig();
+      expect(config.filesMaxFileSize).toBe(20 * 1024 * 1024);
+    });
+
+    it('should parse from env var', () => {
+      process.env.FILES_MAX_FILE_SIZE = '5242880';
+      const config = loadConfig();
+      expect(config.filesMaxFileSize).toBe(5242880);
+    });
+
+    it('should use default for invalid value', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      process.env.FILES_MAX_FILE_SIZE = 'abc';
+      const config = loadConfig();
+      expect(config.filesMaxFileSize).toBe(20 * 1024 * 1024);
+      warnSpy.mockRestore();
+    });
+
+    it('should use default for zero', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      process.env.FILES_MAX_FILE_SIZE = '0';
+      const config = loadConfig();
+      expect(config.filesMaxFileSize).toBe(20 * 1024 * 1024);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('filesMaxTotalStorage', () => {
+    it('should default to 200MB', () => {
+      delete process.env.FILES_MAX_TOTAL_STORAGE;
+      const config = loadConfig();
+      expect(config.filesMaxTotalStorage).toBe(200 * 1024 * 1024);
+    });
+
+    it('should parse from env var', () => {
+      process.env.FILES_MAX_TOTAL_STORAGE = '104857600';
+      const config = loadConfig();
+      expect(config.filesMaxTotalStorage).toBe(104857600);
+    });
+  });
+
+  describe('filesTtlSeconds', () => {
+    it('should default to 3600', () => {
+      delete process.env.FILES_TTL_SECONDS;
+      const config = loadConfig();
+      expect(config.filesTtlSeconds).toBe(3600);
+    });
+
+    it('should parse from env var', () => {
+      process.env.FILES_TTL_SECONDS = '7200';
+      const config = loadConfig();
+      expect(config.filesTtlSeconds).toBe(7200);
+    });
+  });
+
+  describe('filesCleanupIntervalSeconds', () => {
+    it('should default to 60', () => {
+      delete process.env.FILES_CLEANUP_INTERVAL_SECONDS;
+      const config = loadConfig();
+      expect(config.filesCleanupIntervalSeconds).toBe(60);
+    });
+
+    it('should parse from env var', () => {
+      process.env.FILES_CLEANUP_INTERVAL_SECONDS = '120';
+      const config = loadConfig();
+      expect(config.filesCleanupIntervalSeconds).toBe(120);
+    });
+  });
+});

--- a/tests/config/config.files.test.js
+++ b/tests/config/config.files.test.js
@@ -96,6 +96,36 @@ describe('Config - Files API', () => {
     });
   });
 
+  describe('filesMaxCount', () => {
+    it('should default to 1000', () => {
+      delete process.env.FILES_MAX_COUNT;
+      const config = loadConfig();
+      expect(config.filesMaxCount).toBe(1000);
+    });
+
+    it('should parse from env var', () => {
+      process.env.FILES_MAX_COUNT = '500';
+      const config = loadConfig();
+      expect(config.filesMaxCount).toBe(500);
+    });
+
+    it('should use default for invalid value', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      process.env.FILES_MAX_COUNT = 'abc';
+      const config = loadConfig();
+      expect(config.filesMaxCount).toBe(1000);
+      warnSpy.mockRestore();
+    });
+
+    it('should use default for zero', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      process.env.FILES_MAX_COUNT = '0';
+      const config = loadConfig();
+      expect(config.filesMaxCount).toBe(1000);
+      warnSpy.mockRestore();
+    });
+  });
+
   describe('filesTtlSeconds', () => {
     it('should default to 3600', () => {
       delete process.env.FILES_TTL_SECONDS;

--- a/tests/config/config.files.test.js
+++ b/tests/config/config.files.test.js
@@ -140,6 +140,26 @@ describe('Config - Files API', () => {
     });
   });
 
+  describe('filesListEnabled', () => {
+    it('should default to false', () => {
+      delete process.env.FILES_LIST_ENABLED;
+      const config = loadConfig();
+      expect(config.filesListEnabled).toBe(false);
+    });
+
+    it('should be true when set to true', () => {
+      process.env.FILES_LIST_ENABLED = 'true';
+      const config = loadConfig();
+      expect(config.filesListEnabled).toBe(true);
+    });
+
+    it('should be false for any value other than true', () => {
+      process.env.FILES_LIST_ENABLED = 'yes';
+      const config = loadConfig();
+      expect(config.filesListEnabled).toBe(false);
+    });
+  });
+
   describe('filesCleanupIntervalSeconds', () => {
     it('should default to 60', () => {
       delete process.env.FILES_CLEANUP_INTERVAL_SECONDS;

--- a/tests/config/config.timeouts.test.js
+++ b/tests/config/config.timeouts.test.js
@@ -100,7 +100,7 @@ describe('Config - Timeout Configuration', () => {
       const config = new Config();
       expect(config.n8nTimeout).toBe(300000);
       expect(console.warn).toHaveBeenCalledWith(
-        'N8N_TIMEOUT must be a number >= 1000ms. Using default: 300000ms.',
+        'N8N_TIMEOUT must be a number >= 1000. Using default: 300000.',
       );
     });
 
@@ -109,7 +109,7 @@ describe('Config - Timeout Configuration', () => {
       const config = new Config();
       expect(config.serverTimeout).toBe(300000);
       expect(console.warn).toHaveBeenCalledWith(
-        'SERVER_TIMEOUT must be a number >= 1000ms. Using default: 300000ms.',
+        'SERVER_TIMEOUT must be a number >= 1000. Using default: 300000.',
       );
     });
 
@@ -118,7 +118,7 @@ describe('Config - Timeout Configuration', () => {
       const config = new Config();
       expect(config.serverKeepAliveTimeout).toBe(120000);
       expect(console.warn).toHaveBeenCalledWith(
-        'SERVER_KEEP_ALIVE_TIMEOUT must be a number >= 1000ms. Using default: 120000ms.',
+        'SERVER_KEEP_ALIVE_TIMEOUT must be a number >= 1000. Using default: 120000.',
       );
     });
 

--- a/tests/repositories/FileRepository.test.js
+++ b/tests/repositories/FileRepository.test.js
@@ -1,0 +1,172 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const FileRepository = require('../../src/repositories/FileRepository');
+
+describe('FileRepository', () => {
+  let repo;
+
+  beforeEach(() => {
+    repo = new FileRepository();
+  });
+
+  function createEntry(id, bytes = 100) {
+    return {
+      metadata: {
+        id,
+        object: 'file',
+        bytes,
+        created_at: Math.floor(Date.now() / 1000),
+        filename: `${id}.txt`,
+        purpose: 'assistants',
+        status: 'processed',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+      buffer: Buffer.alloc(bytes),
+    };
+  }
+
+  describe('store and get', () => {
+    it('should store and retrieve a file entry', () => {
+      const entry = createEntry('file-1');
+      repo.store('file-1', entry);
+
+      const result = repo.get('file-1');
+      expect(result).toBe(entry);
+    });
+
+    it('should return undefined for missing file', () => {
+      expect(repo.get('nonexistent')).toBeUndefined();
+    });
+
+    it('should track totalBytes on store', () => {
+      repo.store('file-1', createEntry('file-1', 200));
+      repo.store('file-2', createEntry('file-2', 300));
+
+      expect(repo.getTotalBytes()).toBe(500);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an existing file and return true', () => {
+      repo.store('file-1', createEntry('file-1', 150));
+      const result = repo.delete('file-1');
+
+      expect(result).toBe(true);
+      expect(repo.get('file-1')).toBeUndefined();
+    });
+
+    it('should return false for missing file', () => {
+      expect(repo.delete('nonexistent')).toBe(false);
+    });
+
+    it('should decrement totalBytes on delete', () => {
+      repo.store('file-1', createEntry('file-1', 200));
+      repo.store('file-2', createEntry('file-2', 300));
+      repo.delete('file-1');
+
+      expect(repo.getTotalBytes()).toBe(300);
+    });
+  });
+
+  describe('list', () => {
+    beforeEach(() => {
+      const entry1 = createEntry('file-1', 100);
+      entry1.metadata.created_at = 1000;
+      entry1.metadata.purpose = 'assistants';
+
+      const entry2 = createEntry('file-2', 200);
+      entry2.metadata.created_at = 2000;
+      entry2.metadata.purpose = 'vision';
+
+      const entry3 = createEntry('file-3', 300);
+      entry3.metadata.created_at = 3000;
+      entry3.metadata.purpose = 'assistants';
+
+      repo.store('file-1', entry1);
+      repo.store('file-2', entry2);
+      repo.store('file-3', entry3);
+    });
+
+    it('should list all files in descending order by default', () => {
+      const result = repo.list();
+      expect(result).toHaveLength(3);
+      expect(result[0].id).toBe('file-3');
+      expect(result[1].id).toBe('file-2');
+      expect(result[2].id).toBe('file-1');
+    });
+
+    it('should list files in ascending order', () => {
+      const result = repo.list({ order: 'asc' });
+      expect(result[0].id).toBe('file-1');
+      expect(result[2].id).toBe('file-3');
+    });
+
+    it('should filter by purpose', () => {
+      const result = repo.list({ purpose: 'assistants' });
+      expect(result).toHaveLength(2);
+      expect(result.every((m) => m.purpose === 'assistants')).toBe(true);
+    });
+
+    it('should apply limit', () => {
+      const result = repo.list({ limit: 2 });
+      expect(result).toHaveLength(2);
+    });
+
+    it('should paginate with after cursor', () => {
+      const result = repo.list({ after: 'file-3' });
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('file-2');
+    });
+
+    it('should return empty array for empty repo', () => {
+      const emptyRepo = new FileRepository();
+      expect(emptyRepo.list()).toEqual([]);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return the internal map', () => {
+      repo.store('file-1', createEntry('file-1'));
+      const all = repo.getAll();
+      expect(all).toBeInstanceOf(Map);
+      expect(all.size).toBe(1);
+    });
+  });
+
+  describe('getCount', () => {
+    it('should return number of stored files', () => {
+      expect(repo.getCount()).toBe(0);
+      repo.store('file-1', createEntry('file-1'));
+      expect(repo.getCount()).toBe(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all files and reset totalBytes', () => {
+      repo.store('file-1', createEntry('file-1', 100));
+      repo.store('file-2', createEntry('file-2', 200));
+
+      repo.clear();
+
+      expect(repo.getCount()).toBe(0);
+      expect(repo.getTotalBytes()).toBe(0);
+      expect(repo.get('file-1')).toBeUndefined();
+    });
+  });
+});

--- a/tests/routes/files.test.js
+++ b/tests/routes/files.test.js
@@ -132,6 +132,22 @@ describe('files route', () => {
 
       expect(response.status).toBe(413);
     });
+
+    it('should return 413 when file count limit exceeded', async () => {
+      const error = new Error('File count limit of 1000 reached');
+      error.code = 'FILE_COUNT_LIMIT_EXCEEDED';
+      mockFileService.upload.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await request(app)
+        .post('/')
+        .field('purpose', 'assistants')
+        .attach('file', Buffer.from('data'), 'test.txt');
+
+      expect(response.status).toBe(413);
+      expect(response.body.error.message).toMatch(/file count limit/i);
+    });
   });
 
   describe('GET /', () => {
@@ -226,6 +242,20 @@ describe('files route', () => {
       const response = await request(app).get('/file-nonexistent/content');
 
       expect(response.status).toBe(404);
+    });
+
+    it('should produce safe Content-Disposition for filenames with special chars', async () => {
+      mockFileService.getFileContent.mockReturnValue({
+        buffer: Buffer.from('content'),
+        metadata: { filename: 'safe_name_.txt' },
+      });
+
+      const response = await request(app).get('/file-123/content');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-disposition']).toBe('attachment; filename="safe_name_.txt"');
+      const filenameMatch = response.headers['content-disposition'].match(/filename="([^"]*)"/);
+      expect(filenameMatch[1]).not.toMatch(/["\\\x00-\x1f]/);
     });
   });
 });

--- a/tests/routes/files.test.js
+++ b/tests/routes/files.test.js
@@ -1,0 +1,231 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const filesRoute = require('../../src/routes/files');
+
+describe('files route', () => {
+  let app;
+  let mockFileService;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    app = express();
+    app.use(express.json());
+
+    mockFileService = {
+      upload: jest.fn(),
+      getFile: jest.fn(),
+      getFileContent: jest.fn(),
+      deleteFile: jest.fn(),
+      listFiles: jest.fn(),
+    };
+
+    app.locals.fileService = mockFileService;
+    app.locals.config = {
+      filesMaxFileSize: 20 * 1024 * 1024,
+    };
+
+    app.use('/', filesRoute);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('POST /', () => {
+    it('should upload a file and return metadata', async () => {
+      const metadata = {
+        id: 'file-123',
+        object: 'file',
+        bytes: 11,
+        created_at: 1000,
+        filename: 'test.txt',
+        purpose: 'assistants',
+        status: 'processed',
+      };
+      mockFileService.upload.mockReturnValue(metadata);
+
+      const response = await request(app)
+        .post('/')
+        .field('purpose', 'assistants')
+        .attach('file', Buffer.from('hello world'), 'test.txt');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(metadata);
+      expect(mockFileService.upload).toHaveBeenCalledWith(
+        'test.txt',
+        'assistants',
+        expect.any(Buffer),
+      );
+    });
+
+    it('should return 400 if file is missing', async () => {
+      const response = await request(app).post('/').field('purpose', 'assistants');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toMatch(/missing.*file/i);
+    });
+
+    it('should return 400 if purpose is missing', async () => {
+      const response = await request(app).post('/').attach('file', Buffer.from('data'), 'test.txt');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toMatch(/missing.*purpose/i);
+    });
+
+    it('should return 400 for invalid purpose', async () => {
+      const response = await request(app)
+        .post('/')
+        .field('purpose', 'invalid')
+        .attach('file', Buffer.from('data'), 'test.txt');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toMatch(/invalid purpose/i);
+      expect(response.body.error.message).not.toContain("'invalid'");
+    });
+
+    it('should return 413 when file too large', async () => {
+      const error = new Error('File size exceeds maximum');
+      error.code = 'FILE_TOO_LARGE';
+      mockFileService.upload.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await request(app)
+        .post('/')
+        .field('purpose', 'assistants')
+        .attach('file', Buffer.from('data'), 'test.txt');
+
+      expect(response.status).toBe(413);
+    });
+
+    it('should return 413 when storage limit exceeded', async () => {
+      const error = new Error('Total file storage limit exceeded');
+      error.code = 'STORAGE_LIMIT_EXCEEDED';
+      mockFileService.upload.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await request(app)
+        .post('/')
+        .field('purpose', 'assistants')
+        .attach('file', Buffer.from('data'), 'test.txt');
+
+      expect(response.status).toBe(413);
+    });
+  });
+
+  describe('GET /', () => {
+    it('should list files', async () => {
+      const listResult = {
+        object: 'list',
+        data: [{ id: 'file-1', object: 'file' }],
+        has_more: false,
+      };
+      mockFileService.listFiles.mockReturnValue(listResult);
+
+      const response = await request(app).get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(listResult);
+    });
+
+    it('should pass query parameters to listFiles', async () => {
+      mockFileService.listFiles.mockReturnValue({ object: 'list', data: [], has_more: false });
+
+      await request(app).get('/?purpose=vision&limit=10&order=asc&after=file-1');
+
+      expect(mockFileService.listFiles).toHaveBeenCalledWith({
+        purpose: 'vision',
+        limit: '10',
+        order: 'asc',
+        after: 'file-1',
+      });
+    });
+  });
+
+  describe('GET /:file_id', () => {
+    it('should return file metadata', async () => {
+      const metadata = { id: 'file-123', object: 'file', bytes: 100 };
+      mockFileService.getFile.mockReturnValue(metadata);
+
+      const response = await request(app).get('/file-123');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(metadata);
+    });
+
+    it('should return 404 for missing file', async () => {
+      mockFileService.getFile.mockReturnValue(null);
+
+      const response = await request(app).get('/file-nonexistent');
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.type).toBe('invalid_request_error');
+    });
+  });
+
+  describe('DELETE /:file_id', () => {
+    it('should delete file and return confirmation', async () => {
+      const result = { id: 'file-123', object: 'file', deleted: true };
+      mockFileService.deleteFile.mockReturnValue(result);
+
+      const response = await request(app).delete('/file-123');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(result);
+    });
+
+    it('should return 404 for missing file', async () => {
+      mockFileService.deleteFile.mockReturnValue(null);
+
+      const response = await request(app).delete('/file-nonexistent');
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /:file_id/content', () => {
+    it('should return binary content with correct content-type', async () => {
+      const buffer = Buffer.from('PDF content');
+      mockFileService.getFileContent.mockReturnValue({
+        buffer,
+        metadata: { filename: 'doc.pdf' },
+      });
+
+      const response = await request(app).get('/file-123/content');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/application\/pdf/);
+      expect(response.headers['content-disposition']).toMatch(/doc\.pdf/);
+      expect(Buffer.from(response.body).toString()).toBe('PDF content');
+    });
+
+    it('should return 404 for missing file', async () => {
+      mockFileService.getFileContent.mockReturnValue(null);
+
+      const response = await request(app).get('/file-nonexistent/content');
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/routes/files.test.js
+++ b/tests/routes/files.test.js
@@ -42,6 +42,7 @@ describe('files route', () => {
     app.locals.fileService = mockFileService;
     app.locals.config = {
       filesMaxFileSize: 20 * 1024 * 1024,
+      filesListEnabled: true,
     };
 
     app.use('/', filesRoute);
@@ -151,6 +152,16 @@ describe('files route', () => {
   });
 
   describe('GET /', () => {
+    it('should return empty list when filesListEnabled is false', async () => {
+      app.locals.config.filesListEnabled = false;
+
+      const response = await request(app).get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ object: 'list', data: [], has_more: false });
+      expect(mockFileService.listFiles).not.toHaveBeenCalled();
+    });
+
     it('should list files', async () => {
       const listResult = {
         object: 'list',

--- a/tests/services/fileService.test.js
+++ b/tests/services/fileService.test.js
@@ -1,0 +1,298 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const FileRepository = require('../../src/repositories/FileRepository');
+const FileService = require('../../src/services/fileService');
+
+describe('FileService', () => {
+  let repo;
+  let service;
+  let config;
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    repo = new FileRepository();
+    config = {
+      filesMaxFileSize: 1024 * 1024, // 1MB
+      filesMaxTotalStorage: 10 * 1024 * 1024, // 10MB
+      filesTtlSeconds: 3600,
+      filesCleanupIntervalSeconds: 60,
+    };
+    service = new FileService(repo, config);
+  });
+
+  afterEach(() => {
+    service.stopCleanupInterval();
+    consoleLogSpy.mockRestore();
+  });
+
+  describe('upload', () => {
+    it('should store a file and return metadata', () => {
+      const buffer = Buffer.from('hello world');
+      const result = service.upload('test.txt', 'assistants', buffer);
+
+      expect(result.id).toMatch(/^file-/);
+      expect(result.object).toBe('file');
+      expect(result.bytes).toBe(buffer.length);
+      expect(result.filename).toBe('test.txt');
+      expect(result.purpose).toBe('assistants');
+      expect(result.status).toBe('processed');
+      expect(result.expires_at).toBeGreaterThan(result.created_at);
+    });
+
+    it('should reject files exceeding max file size', () => {
+      const buffer = Buffer.alloc(config.filesMaxFileSize + 1);
+
+      expect(() => service.upload('large.bin', 'assistants', buffer)).toThrow(/exceeds maximum/);
+    });
+
+    it('should set FILE_TOO_LARGE error code', () => {
+      const buffer = Buffer.alloc(config.filesMaxFileSize + 1);
+
+      expect(() => service.upload('large.bin', 'assistants', buffer)).toThrow(
+        expect.objectContaining({ code: 'FILE_TOO_LARGE' }),
+      );
+    });
+
+    it('should reject when total storage would be exceeded', () => {
+      // Use a small total storage limit for this test
+      config.filesMaxTotalStorage = 500;
+      config.filesMaxFileSize = 1000;
+      const buffer = Buffer.alloc(400);
+      service.upload('big.bin', 'assistants', buffer);
+
+      // This should exceed the 500 byte total limit
+      const smallBuffer = Buffer.alloc(200);
+      expect(() => service.upload('small.bin', 'assistants', smallBuffer)).toThrow(
+        /storage limit exceeded/i,
+      );
+    });
+
+    it('should set STORAGE_LIMIT_EXCEEDED error code', () => {
+      config.filesMaxTotalStorage = 500;
+      config.filesMaxFileSize = 1000;
+      const buffer = Buffer.alloc(400);
+      service.upload('big.bin', 'assistants', buffer);
+
+      expect(() => service.upload('small.bin', 'assistants', Buffer.alloc(200))).toThrow(
+        expect.objectContaining({ code: 'STORAGE_LIMIT_EXCEEDED' }),
+      );
+    });
+  });
+
+  describe('getFile', () => {
+    it('should return metadata for existing file', () => {
+      const buffer = Buffer.from('test');
+      const uploaded = service.upload('test.txt', 'assistants', buffer);
+
+      const result = service.getFile(uploaded.id);
+      expect(result).toEqual(uploaded);
+    });
+
+    it('should return null for missing file', () => {
+      expect(service.getFile('file-nonexistent')).toBeNull();
+    });
+
+    it('should return null and evict expired file', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+      const entry = repo.get(uploaded.id);
+      entry.metadata.expires_at = Math.floor(Date.now() / 1000) - 1;
+
+      expect(service.getFile(uploaded.id)).toBeNull();
+      expect(repo.get(uploaded.id)).toBeUndefined();
+    });
+  });
+
+  describe('getFileContent', () => {
+    it('should return buffer and metadata for existing file', () => {
+      const buffer = Buffer.from('test content');
+      const uploaded = service.upload('test.txt', 'assistants', buffer);
+
+      const result = service.getFileContent(uploaded.id);
+      expect(result.buffer).toEqual(buffer);
+      expect(result.metadata).toEqual(uploaded);
+    });
+
+    it('should return null for missing file', () => {
+      expect(service.getFileContent('file-nonexistent')).toBeNull();
+    });
+
+    it('should return null and evict expired file', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+      const entry = repo.get(uploaded.id);
+      entry.metadata.expires_at = Math.floor(Date.now() / 1000) - 1;
+
+      expect(service.getFileContent(uploaded.id)).toBeNull();
+      expect(repo.get(uploaded.id)).toBeUndefined();
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should delete and return confirmation', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+
+      const result = service.deleteFile(uploaded.id);
+      expect(result).toEqual({
+        id: uploaded.id,
+        object: 'file',
+        deleted: true,
+      });
+    });
+
+    it('should return null for missing file', () => {
+      expect(service.deleteFile('file-nonexistent')).toBeNull();
+    });
+
+    it('should make file inaccessible after deletion', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+      service.deleteFile(uploaded.id);
+
+      expect(service.getFile(uploaded.id)).toBeNull();
+    });
+  });
+
+  describe('listFiles', () => {
+    it('should return list structure with data and has_more', () => {
+      service.upload('a.txt', 'assistants', Buffer.from('a'));
+      service.upload('b.txt', 'vision', Buffer.from('b'));
+
+      const result = service.listFiles();
+      expect(result.object).toBe('list');
+      expect(result.data).toHaveLength(2);
+      expect(result.has_more).toBe(false);
+    });
+
+    it('should filter by purpose', () => {
+      service.upload('a.txt', 'assistants', Buffer.from('a'));
+      service.upload('b.txt', 'vision', Buffer.from('b'));
+
+      const result = service.listFiles({ purpose: 'vision' });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].purpose).toBe('vision');
+    });
+
+    it('should indicate has_more when results exceed limit', () => {
+      service.upload('a.txt', 'assistants', Buffer.from('a'));
+      service.upload('b.txt', 'assistants', Buffer.from('b'));
+      service.upload('c.txt', 'assistants', Buffer.from('c'));
+
+      const result = service.listFiles({ limit: 2 });
+      expect(result.data).toHaveLength(2);
+      expect(result.has_more).toBe(true);
+    });
+
+    it('should clamp limit to valid range', () => {
+      service.upload('a.txt', 'assistants', Buffer.from('a'));
+
+      const result = service.listFiles({ limit: -5 });
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should remove expired files', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+
+      // Manually set expiration to past
+      const entry = repo.get(uploaded.id);
+      entry.metadata.expires_at = Math.floor(Date.now() / 1000) - 1;
+
+      const cleaned = service.cleanup();
+      expect(cleaned).toBe(1);
+      expect(repo.get(uploaded.id)).toBeUndefined();
+    });
+
+    it('should keep non-expired files', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+
+      const cleaned = service.cleanup();
+      expect(cleaned).toBe(0);
+      expect(service.getFile(uploaded.id)).not.toBeNull();
+    });
+
+    it('should log when files are cleaned', () => {
+      const uploaded = service.upload('test.txt', 'assistants', Buffer.from('test'));
+      const entry = repo.get(uploaded.id);
+      entry.metadata.expires_at = Math.floor(Date.now() / 1000) - 1;
+
+      service.cleanup();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('File cleanup: removed 1 expired file(s)'),
+      );
+    });
+  });
+
+  describe('cleanup interval', () => {
+    it('should start and stop cleanup interval', () => {
+      jest.useFakeTimers();
+
+      service.startCleanupInterval();
+      expect(service.cleanupTimer).not.toBeNull();
+
+      service.stopCleanupInterval();
+      expect(service.cleanupTimer).toBeNull();
+
+      jest.useRealTimers();
+    });
+
+    it('should not start multiple intervals', () => {
+      jest.useFakeTimers();
+
+      service.startCleanupInterval();
+      const firstTimer = service.cleanupTimer;
+      service.startCleanupInterval();
+      expect(service.cleanupTimer).toBe(firstTimer);
+
+      service.stopCleanupInterval();
+      jest.useRealTimers();
+    });
+
+    it('should handle stopCleanupInterval when no timer exists', () => {
+      expect(() => service.stopCleanupInterval()).not.toThrow();
+    });
+  });
+
+  describe('static methods', () => {
+    it('generateFileId should return file- prefixed ID', () => {
+      const id = FileService.generateFileId();
+      expect(id).toMatch(/^file-[0-9a-f-]+$/);
+    });
+
+    it('isValidPurpose should validate known purposes', () => {
+      expect(FileService.isValidPurpose('assistants')).toBe(true);
+      expect(FileService.isValidPurpose('vision')).toBe(true);
+      expect(FileService.isValidPurpose('batch')).toBe(true);
+      expect(FileService.isValidPurpose('fine-tune')).toBe(true);
+      expect(FileService.isValidPurpose('user_data')).toBe(true);
+      expect(FileService.isValidPurpose('evals')).toBe(true);
+    });
+
+    it('isValidPurpose should reject invalid purposes', () => {
+      expect(FileService.isValidPurpose('invalid')).toBe(false);
+      expect(FileService.isValidPurpose('')).toBe(false);
+    });
+
+    it('isExpired should detect expired entries', () => {
+      const past = { metadata: { expires_at: Math.floor(Date.now() / 1000) - 1 } };
+      const future = { metadata: { expires_at: Math.floor(Date.now() / 1000) + 3600 } };
+      expect(FileService.isExpired(past)).toBe(true);
+      expect(FileService.isExpired(future)).toBe(false);
+    });
+  });
+});

--- a/tests/services/fileService.test.js
+++ b/tests/services/fileService.test.js
@@ -31,6 +31,7 @@ describe('FileService', () => {
     config = {
       filesMaxFileSize: 1024 * 1024, // 1MB
       filesMaxTotalStorage: 10 * 1024 * 1024, // 10MB
+      filesMaxCount: 1000,
       filesTtlSeconds: 3600,
       filesCleanupIntervalSeconds: 60,
     };
@@ -93,6 +94,59 @@ describe('FileService', () => {
       expect(() => service.upload('small.bin', 'assistants', Buffer.alloc(200))).toThrow(
         expect.objectContaining({ code: 'STORAGE_LIMIT_EXCEEDED' }),
       );
+    });
+
+    it('should reject when file count limit is reached', () => {
+      config.filesMaxCount = 2;
+      service.upload('a.txt', 'assistants', Buffer.from('a'));
+      service.upload('b.txt', 'assistants', Buffer.from('b'));
+
+      expect(() => service.upload('c.txt', 'assistants', Buffer.from('c'))).toThrow(
+        /file count limit/i,
+      );
+    });
+
+    it('should set FILE_COUNT_LIMIT_EXCEEDED error code', () => {
+      config.filesMaxCount = 1;
+      service.upload('a.txt', 'assistants', Buffer.from('a'));
+
+      expect(() => service.upload('b.txt', 'assistants', Buffer.from('b'))).toThrow(
+        expect.objectContaining({ code: 'FILE_COUNT_LIMIT_EXCEEDED' }),
+      );
+    });
+
+    it('should allow upload after deleting when at count limit', () => {
+      config.filesMaxCount = 1;
+      const first = service.upload('a.txt', 'assistants', Buffer.from('a'));
+      service.deleteFile(first.id);
+
+      const second = service.upload('b.txt', 'assistants', Buffer.from('b'));
+      expect(second.id).toMatch(/^file-/);
+    });
+
+    it('should sanitize filenames with path traversal', () => {
+      const result = service.upload('../../etc/passwd', 'assistants', Buffer.from('x'));
+      expect(result.filename).toBe('passwd');
+    });
+
+    it('should sanitize filenames with control characters', () => {
+      const result = service.upload('file\x00name\x1f.txt', 'assistants', Buffer.from('x'));
+      expect(result.filename).toBe('filename.txt');
+    });
+
+    it('should sanitize filenames with double-quote characters', () => {
+      const result = service.upload('file"name.txt', 'assistants', Buffer.from('x'));
+      expect(result.filename).toBe('file_name.txt');
+    });
+
+    it('should strip Windows backslash paths to base filename', () => {
+      const result = service.upload('C:\\Users\\docs\\report.pdf', 'assistants', Buffer.from('x'));
+      expect(result.filename).toBe('report.pdf');
+    });
+
+    it('should use fallback for empty filenames', () => {
+      const result = service.upload('', 'assistants', Buffer.from('x'));
+      expect(result.filename).toBe('unnamed');
     });
   });
 
@@ -293,6 +347,74 @@ describe('FileService', () => {
       const future = { metadata: { expires_at: Math.floor(Date.now() / 1000) + 3600 } };
       expect(FileService.isExpired(past)).toBe(true);
       expect(FileService.isExpired(future)).toBe(false);
+    });
+  });
+
+  describe('sanitizeFilename', () => {
+    it('should return clean filenames unchanged', () => {
+      expect(FileService.sanitizeFilename('report.pdf')).toBe('report.pdf');
+      expect(FileService.sanitizeFilename('my-file_2024.txt')).toBe('my-file_2024.txt');
+    });
+
+    it('should strip Unix path components', () => {
+      expect(FileService.sanitizeFilename('/etc/passwd')).toBe('passwd');
+      expect(FileService.sanitizeFilename('../../secret.txt')).toBe('secret.txt');
+    });
+
+    it('should strip Windows path components', () => {
+      expect(FileService.sanitizeFilename('C:\\Users\\evil\\file.exe')).toBe('file.exe');
+      expect(FileService.sanitizeFilename('..\\..\\secret.txt')).toBe('secret.txt');
+    });
+
+    it('should remove control characters', () => {
+      expect(FileService.sanitizeFilename('file\x00.txt')).toBe('file.txt');
+      expect(FileService.sanitizeFilename('fi\x0ale\x1f.txt')).toBe('file.txt');
+      expect(FileService.sanitizeFilename('file\x7f.txt')).toBe('file.txt');
+    });
+
+    it('should replace double-quotes with underscores', () => {
+      expect(FileService.sanitizeFilename('file"name.txt')).toBe('file_name.txt');
+    });
+
+    it('should treat backslash as path separator and strip to base name', () => {
+      expect(FileService.sanitizeFilename('file\\name.txt')).toBe('name.txt');
+      expect(FileService.sanitizeFilename('dir\\sub\\file.txt')).toBe('file.txt');
+    });
+
+    it('should truncate filenames exceeding max length, preserving extension', () => {
+      const longName = `${'a'.repeat(300)}.pdf`;
+      const result = FileService.sanitizeFilename(longName);
+      expect(result.length).toBe(255);
+      expect(result.endsWith('.pdf')).toBe(true);
+    });
+
+    it('should truncate filenames without extension', () => {
+      const longName = 'a'.repeat(300);
+      const result = FileService.sanitizeFilename(longName);
+      expect(result.length).toBe(255);
+    });
+
+    it('should return unnamed for null/undefined/empty', () => {
+      expect(FileService.sanitizeFilename(null)).toBe('unnamed');
+      expect(FileService.sanitizeFilename(undefined)).toBe('unnamed');
+      expect(FileService.sanitizeFilename('')).toBe('unnamed');
+    });
+
+    it('should return unnamed for non-string inputs', () => {
+      expect(FileService.sanitizeFilename(123)).toBe('unnamed');
+      expect(FileService.sanitizeFilename({})).toBe('unnamed');
+    });
+
+    it('should return unnamed when only dots remain', () => {
+      expect(FileService.sanitizeFilename('.')).toBe('unnamed');
+    });
+
+    it('should handle whitespace-only filenames', () => {
+      expect(FileService.sanitizeFilename('   ')).toBe('unnamed');
+    });
+
+    it('should trim leading/trailing whitespace', () => {
+      expect(FileService.sanitizeFilename('  file.txt  ')).toBe('file.txt');
     });
   });
 });

--- a/tests/services/webhookNotifierService.test.js
+++ b/tests/services/webhookNotifierService.test.js
@@ -1,9 +1,9 @@
-const WebhookNotifier = require('../../src/services/webhookNotifier');
+const WebhookNotifierService = require('../../src/services/webhookNotifierService');
 const axios = require('axios');
 
 jest.mock('axios');
 
-describe('WebhookNotifier', () => {
+describe('WebhookNotifierService', () => {
   let consoleLogSpy;
   let consoleWarnSpy;
   let consoleErrorSpy;
@@ -26,19 +26,19 @@ describe('WebhookNotifier', () => {
 
   describe('constructor', () => {
     test('should be disabled when no webhook URL is provided', () => {
-      const notifier = new WebhookNotifier({});
+      const notifier = new WebhookNotifierService({});
       expect(notifier.enabled).toBe(false);
     });
 
     test('should be enabled when webhook URL is provided', () => {
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
       });
       expect(notifier.enabled).toBe(true);
     });
 
     test('should use default values when not provided', () => {
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
       });
       expect(notifier.timeout).toBe(5000);
@@ -48,7 +48,7 @@ describe('WebhookNotifier', () => {
     });
 
     test('should use custom configuration values', () => {
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
         timeout: 10000,
         maxRetries: 5,
@@ -64,7 +64,7 @@ describe('WebhookNotifier', () => {
 
   describe('notify', () => {
     test('should not call webhook when disabled', async () => {
-      const notifier = new WebhookNotifier({});
+      const notifier = new WebhookNotifierService({});
       const payload = { type: 'models_changed', models: {} };
 
       await notifier.notify(payload);
@@ -75,7 +75,7 @@ describe('WebhookNotifier', () => {
     test('should call webhook with correct payload and headers', async () => {
       axios.post.mockResolvedValueOnce({ status: 200 });
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
       });
 
@@ -98,7 +98,7 @@ describe('WebhookNotifier', () => {
     test('should include authorization header when bearer token provided', async () => {
       axios.post.mockResolvedValueOnce({ status: 200 });
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
         bearerToken: 'secret-token',
       });
@@ -123,7 +123,7 @@ describe('WebhookNotifier', () => {
         .mockRejectedValueOnce(error)
         .mockResolvedValueOnce({ status: 200 });
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
         maxRetries: 3,
       });
@@ -140,7 +140,7 @@ describe('WebhookNotifier', () => {
       const error = new Error('Network error');
       axios.post.mockRejectedValue(error);
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
         maxRetries: 2,
       });
@@ -162,7 +162,7 @@ describe('WebhookNotifier', () => {
       const error = new Error('Network error');
       axios.post.mockRejectedValue(error);
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
         maxRetries: 2,
       });
@@ -176,7 +176,7 @@ describe('WebhookNotifier', () => {
     test('should log success message on successful notification', async () => {
       axios.post.mockResolvedValueOnce({ status: 200 });
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
       });
 
@@ -192,7 +192,7 @@ describe('WebhookNotifier', () => {
     test('should respect custom timeout', async () => {
       axios.post.mockResolvedValueOnce({ status: 200 });
 
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
         timeout: 15000,
       });
@@ -218,10 +218,10 @@ describe('WebhookNotifier', () => {
         'model-2': 'https://n8n.example.com/webhook/2',
       };
 
-      const payload = WebhookNotifier.createPayload(
+      const payload = WebhookNotifierService.createPayload(
         models,
         'JsonFileModelLoader',
-        WebhookNotifier.EventType.MODELS_CHANGED,
+        WebhookNotifierService.EventType.MODELS_CHANGED,
       );
 
       expect(payload.type).toBe('models_changed');
@@ -237,10 +237,10 @@ describe('WebhookNotifier', () => {
         'model-1': 'https://n8n.example.com/webhook/1',
       };
 
-      const payload = WebhookNotifier.createPayload(
+      const payload = WebhookNotifierService.createPayload(
         models,
         'N8nApiModelLoader',
-        WebhookNotifier.EventType.MODELS_LOADED,
+        WebhookNotifierService.EventType.MODELS_LOADED,
       );
 
       expect(payload.type).toBe('models_loaded');
@@ -250,10 +250,10 @@ describe('WebhookNotifier', () => {
     });
 
     test('should handle empty models object', () => {
-      const payload = WebhookNotifier.createPayload(
+      const payload = WebhookNotifierService.createPayload(
         {},
         'N8nApiModelLoader',
-        WebhookNotifier.EventType.MODELS_CHANGED,
+        WebhookNotifierService.EventType.MODELS_CHANGED,
       );
 
       expect(payload.modelCount).toBe(0);
@@ -262,10 +262,10 @@ describe('WebhookNotifier', () => {
 
     test('should use current timestamp', () => {
       const beforeTime = Date.now();
-      const payload = WebhookNotifier.createPayload(
+      const payload = WebhookNotifierService.createPayload(
         {},
         'StaticModelLoader',
-        WebhookNotifier.EventType.MODELS_LOADED,
+        WebhookNotifierService.EventType.MODELS_LOADED,
       );
       const afterTime = Date.now();
 
@@ -276,20 +276,20 @@ describe('WebhookNotifier', () => {
 
     test('should throw error when eventType is not provided', () => {
       expect(() => {
-        WebhookNotifier.createPayload({}, 'JsonFileModelLoader');
+        WebhookNotifierService.createPayload({}, 'JsonFileModelLoader');
       }).toThrow('eventType is required');
     });
 
     test('should throw error when eventType is null', () => {
       expect(() => {
-        WebhookNotifier.createPayload({}, 'JsonFileModelLoader', null);
+        WebhookNotifierService.createPayload({}, 'JsonFileModelLoader', null);
       }).toThrow('eventType is required');
     });
   });
 
   describe('sleep', () => {
     test('should sleep for specified duration', async () => {
-      const notifier = new WebhookNotifier({
+      const notifier = new WebhookNotifierService({
         webhookUrl: 'https://example.com/webhook',
       });
 

--- a/tests/utils/fileResolver.test.js
+++ b/tests/utils/fileResolver.test.js
@@ -1,0 +1,305 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const {
+  resolveFileReferences,
+  resolveAttachments,
+  resolveContentParts,
+  bufferToDataUrl,
+} = require('../../src/utils/fileResolver');
+const { getMimeTypeFromFilename } = require('../../src/utils/mimeTypes');
+
+describe('fileResolver', () => {
+  let mockFileService;
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    mockFileService = {
+      getFileContent: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('resolveFileReferences', () => {
+    it('should return messages unchanged if no file references', () => {
+      const messages = [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there' },
+      ];
+
+      const result = resolveFileReferences(messages, mockFileService);
+      expect(result).toEqual(messages);
+    });
+
+    it('should handle null/undefined messages', () => {
+      expect(resolveFileReferences(null, mockFileService)).toBeNull();
+      expect(resolveFileReferences(undefined, mockFileService)).toBeUndefined();
+    });
+
+    it('should resolve attachments in messages', () => {
+      const buffer = Buffer.from('pdf content');
+      mockFileService.getFileContent.mockReturnValue({
+        buffer,
+        metadata: { filename: 'doc.pdf' },
+      });
+
+      const messages = [
+        {
+          role: 'user',
+          content: 'Summarize this',
+          attachments: [{ file_id: 'file-123' }],
+        },
+      ];
+
+      const result = resolveFileReferences(messages, mockFileService);
+      expect(result[0].attachments).toBeUndefined();
+      expect(result[0].content).toHaveLength(2);
+      expect(result[0].content[0]).toEqual({ type: 'text', text: 'Summarize this' });
+      expect(result[0].content[1].type).toBe('image_url');
+      expect(result[0].content[1].image_url.url).toMatch(/^data:application\/pdf;base64,/);
+    });
+
+    it('should resolve content parts with file- prefixed URLs', () => {
+      const buffer = Buffer.from('image data');
+      mockFileService.getFileContent.mockReturnValue({
+        buffer,
+        metadata: { filename: 'photo.png' },
+      });
+
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is this?' },
+            { type: 'image_url', image_url: { url: 'file-456' } },
+          ],
+        },
+      ];
+
+      const result = resolveFileReferences(messages, mockFileService);
+      expect(result[0].content[1].image_url.url).toMatch(/^data:image\/png;base64,/);
+    });
+
+    it('should handle mixed messages', () => {
+      mockFileService.getFileContent.mockReturnValue({
+        buffer: Buffer.from('data'),
+        metadata: { filename: 'file.txt' },
+      });
+
+      const messages = [
+        { role: 'system', content: 'You are helpful' },
+        {
+          role: 'user',
+          content: 'Check this',
+          attachments: [{ file_id: 'file-1' }],
+        },
+        { role: 'assistant', content: 'Sure' },
+      ];
+
+      const result = resolveFileReferences(messages, mockFileService);
+      expect(result[0].content).toBe('You are helpful');
+      expect(result[1].content).toHaveLength(2);
+      expect(result[2].content).toBe('Sure');
+    });
+  });
+
+  describe('resolveAttachments', () => {
+    it('should convert string content to array format', () => {
+      mockFileService.getFileContent.mockReturnValue({
+        buffer: Buffer.from('data'),
+        metadata: { filename: 'file.txt' },
+      });
+
+      const message = {
+        role: 'user',
+        content: 'Hello',
+        attachments: [{ file_id: 'file-1' }],
+      };
+
+      const result = resolveAttachments(message, mockFileService);
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content[0]).toEqual({ type: 'text', text: 'Hello' });
+    });
+
+    it('should handle empty string content', () => {
+      mockFileService.getFileContent.mockReturnValue({
+        buffer: Buffer.from('data'),
+        metadata: { filename: 'file.txt' },
+      });
+
+      const message = {
+        role: 'user',
+        content: '',
+        attachments: [{ file_id: 'file-1' }],
+      };
+
+      const result = resolveAttachments(message, mockFileService);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('image_url');
+    });
+
+    it('should skip attachments without file_id', () => {
+      const message = {
+        role: 'user',
+        content: 'Hello',
+        attachments: [{ tools: [{ type: 'file_search' }] }],
+      };
+
+      const result = resolveAttachments(message, mockFileService);
+      expect(result).toBe(message);
+    });
+
+    it('should warn and skip missing files', () => {
+      mockFileService.getFileContent.mockReturnValue(null);
+
+      const message = {
+        role: 'user',
+        content: 'Hello',
+        attachments: [{ file_id: 'file-expired' }],
+      };
+
+      const result = resolveAttachments(message, mockFileService);
+      expect(result).toBe(message);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('file-expired'));
+    });
+
+    it('should handle array content with attachments', () => {
+      mockFileService.getFileContent.mockReturnValue({
+        buffer: Buffer.from('data'),
+        metadata: { filename: 'file.txt' },
+      });
+
+      const message = {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        attachments: [{ file_id: 'file-1' }],
+      };
+
+      const result = resolveAttachments(message, mockFileService);
+      expect(result.content).toHaveLength(2);
+    });
+  });
+
+  describe('resolveContentParts', () => {
+    it('should replace file- prefixed URLs with data URLs', () => {
+      mockFileService.getFileContent.mockReturnValue({
+        buffer: Buffer.from('image data'),
+        metadata: { filename: 'photo.jpg' },
+      });
+
+      const message = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Look' },
+          { type: 'image_url', image_url: { url: 'file-123' } },
+        ],
+      };
+
+      const result = resolveContentParts(message, mockFileService);
+      expect(result.content[0]).toEqual({ type: 'text', text: 'Look' });
+      expect(result.content[1].image_url.url).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it('should not modify non-file URLs', () => {
+      const message = {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'https://example.com/img.png' } }],
+      };
+
+      const result = resolveContentParts(message, mockFileService);
+      expect(result).toBe(message);
+    });
+
+    it('should not modify data URLs', () => {
+      const message = {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,abc' } }],
+      };
+
+      const result = resolveContentParts(message, mockFileService);
+      expect(result).toBe(message);
+    });
+
+    it('should warn and keep original for missing files', () => {
+      mockFileService.getFileContent.mockReturnValue(null);
+
+      const message = {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'file-gone' } }],
+      };
+
+      const result = resolveContentParts(message, mockFileService);
+      expect(result).toBe(message);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('file-gone'));
+    });
+
+    it('should skip non-image_url parts', () => {
+      const message = {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      };
+
+      const result = resolveContentParts(message, mockFileService);
+      expect(result).toBe(message);
+    });
+  });
+
+  describe('bufferToDataUrl', () => {
+    it('should create data URL from buffer and filename', () => {
+      const buffer = Buffer.from('test');
+      const result = bufferToDataUrl(buffer, 'doc.pdf');
+      expect(result).toBe(`data:application/pdf;base64,${buffer.toString('base64')}`);
+    });
+  });
+
+  describe('getMimeTypeFromFilename', () => {
+    it('should return correct mime types for known extensions', () => {
+      expect(getMimeTypeFromFilename('photo.png')).toBe('image/png');
+      expect(getMimeTypeFromFilename('photo.jpg')).toBe('image/jpeg');
+      expect(getMimeTypeFromFilename('photo.jpeg')).toBe('image/jpeg');
+      expect(getMimeTypeFromFilename('anim.gif')).toBe('image/gif');
+      expect(getMimeTypeFromFilename('img.webp')).toBe('image/webp');
+      expect(getMimeTypeFromFilename('icon.svg')).toBe('image/svg+xml');
+      expect(getMimeTypeFromFilename('doc.pdf')).toBe('application/pdf');
+      expect(getMimeTypeFromFilename('notes.txt')).toBe('text/plain');
+      expect(getMimeTypeFromFilename('data.json')).toBe('application/json');
+      expect(getMimeTypeFromFilename('doc.doc')).toBe('application/msword');
+      expect(getMimeTypeFromFilename('doc.docx')).toBe(
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      );
+      expect(getMimeTypeFromFilename('sheet.xls')).toBe('application/vnd.ms-excel');
+      expect(getMimeTypeFromFilename('sheet.xlsx')).toBe(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+      expect(getMimeTypeFromFilename('data.csv')).toBe('text/csv');
+    });
+
+    it('should return octet-stream for unknown extensions', () => {
+      expect(getMimeTypeFromFilename('file.xyz')).toBe('application/octet-stream');
+    });
+
+    it('should handle empty/null filenames', () => {
+      expect(getMimeTypeFromFilename('')).toBe('application/octet-stream');
+      expect(getMimeTypeFromFilename(null)).toBe('application/octet-stream');
+    });
+  });
+});

--- a/tests/utils/mimeTypes.test.js
+++ b/tests/utils/mimeTypes.test.js
@@ -31,6 +31,12 @@ describe('mimeTypes', () => {
       expect(getExtensionFromMimeType('application/pdf')).toBe('pdf');
       expect(getExtensionFromMimeType('text/csv')).toBe('csv');
       expect(getExtensionFromMimeType('application/msword')).toBe('doc');
+      expect(getExtensionFromMimeType('application/vnd.ms-powerpoint')).toBe('ppt');
+      expect(
+        getExtensionFromMimeType(
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        ),
+      ).toBe('pptx');
     });
 
     it('should return bin for unknown MIME types', () => {
@@ -47,6 +53,9 @@ describe('mimeTypes', () => {
       expect(getMimeTypeFromFilename('data.csv')).toBe('text/csv');
       expect(getMimeTypeFromFilename('doc.docx')).toBe(
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      );
+      expect(getMimeTypeFromFilename('slides.pptx')).toBe(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
       );
     });
 

--- a/tests/utils/mimeTypes.test.js
+++ b/tests/utils/mimeTypes.test.js
@@ -1,0 +1,70 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const {
+  getExtensionFromMimeType,
+  getMimeTypeFromFilename,
+  MIME_TO_EXT,
+  EXT_TO_MIME,
+} = require('../../src/utils/mimeTypes');
+
+describe('mimeTypes', () => {
+  describe('getExtensionFromMimeType', () => {
+    it('should return correct extensions for known MIME types', () => {
+      expect(getExtensionFromMimeType('image/png')).toBe('png');
+      expect(getExtensionFromMimeType('image/jpeg')).toBe('jpg');
+      expect(getExtensionFromMimeType('application/pdf')).toBe('pdf');
+      expect(getExtensionFromMimeType('text/csv')).toBe('csv');
+      expect(getExtensionFromMimeType('application/msword')).toBe('doc');
+    });
+
+    it('should return bin for unknown MIME types', () => {
+      expect(getExtensionFromMimeType('application/unknown')).toBe('bin');
+    });
+  });
+
+  describe('getMimeTypeFromFilename', () => {
+    it('should return correct MIME types for known extensions', () => {
+      expect(getMimeTypeFromFilename('photo.png')).toBe('image/png');
+      expect(getMimeTypeFromFilename('photo.jpg')).toBe('image/jpeg');
+      expect(getMimeTypeFromFilename('photo.jpeg')).toBe('image/jpeg');
+      expect(getMimeTypeFromFilename('doc.pdf')).toBe('application/pdf');
+      expect(getMimeTypeFromFilename('data.csv')).toBe('text/csv');
+      expect(getMimeTypeFromFilename('doc.docx')).toBe(
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      );
+    });
+
+    it('should return octet-stream for unknown extensions', () => {
+      expect(getMimeTypeFromFilename('file.xyz')).toBe('application/octet-stream');
+    });
+
+    it('should handle empty/null filenames', () => {
+      expect(getMimeTypeFromFilename('')).toBe('application/octet-stream');
+      expect(getMimeTypeFromFilename(null)).toBe('application/octet-stream');
+    });
+  });
+
+  describe('maps consistency', () => {
+    it('MIME_TO_EXT and EXT_TO_MIME should be inverse for all entries', () => {
+      for (const [_mime, ext] of Object.entries(MIME_TO_EXT)) {
+        expect(EXT_TO_MIME[ext]).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements OpenAI `/v1/files` endpoints with in-memory storage and TTL-based expiration (fixes #71)
- Resolves file_id references in chat completion messages to inline base64 data URLs before forwarding to n8n
- Adds shared MIME type utility, unified env int parser, and renames `WebhookNotifier` → `WebhookNotifierService` for consistency

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/v1/files` | Upload file (multipart/form-data) |
| `GET` | `/v1/files` | List files with filtering/pagination |
| `GET` | `/v1/files/:file_id` | Get file metadata |
| `GET` | `/v1/files/:file_id/content` | Download file content |
| `DELETE` | `/v1/files/:file_id` | Delete file |

## Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `FILES_ENABLED` | `true` | Enable/disable Files API |
| `FILES_MAX_FILE_SIZE` | 20MB | Max size per file |
| `FILES_MAX_TOTAL_STORAGE` | 200MB | Max total in-memory storage |
| `FILES_TTL_SECONDS` | 3600 | File expiration time |
| `FILES_CLEANUP_INTERVAL_SECONDS` | 60 | Cleanup sweep interval |

## Manual testing

Update your existing installation to use the PR image tag:

```
ghcr.io/sveneisenschmidt/n8n-openai-bridge:pr-72
```

Add the new environment variables to your configuration (see table above) and restart.

Test the new `/v1/files` endpoints and file attachments in chat completions with your existing setup.

## Test plan

- [x] 76 test suites, 716 tests passing
- [x] 96%+ coverage maintained
- [x] Lint and format clean
- [ ] Manual test: upload, list, retrieve, delete via curl
- [ ] Integration test: upload file, reference in chat completion, verify n8n receives content
- [ ] Open WebUI: attach PDF/DOCX, verify file reaches n8n workflow
