### PR TITLE
Include full conversation history as single message if session ID is unavailable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ n8n-openai-bridge/
 │   ├── services/          # Business logic (session, user, validation)
 │   ├── loaders/           # Model loader architecture (file, json-http, n8n-api, static)
 │   ├── notifiers/         # Webhook notifiers (model changes)
-│   └── utils/             # Utility functions
+│   └── utils/             # Utility functions (session, user, message consolidation)
 ├── tests/                 # Unit tests
 │   ├── image-tests/       # Modular image validation scenarios
 │   └── test-image-build.sh  # Image test orchestrator
@@ -59,6 +59,8 @@ n8n-openai-bridge/
 Client → Auth Middleware → Route Handler → n8nClient → n8n Webhook
               ↓
          Session/User Context → Model Validation → Streaming/Non-streaming Response
+              ↓
+         No session ID? → Generate UUID → Consolidate messages into single prompt
 ```
 
 **Key Components:**
@@ -69,6 +71,7 @@ Client → Auth Middleware → Route Handler → n8nClient → n8n Webhook
 - `server.js` - Express setup, OpenAI endpoints
 - `n8nClient.js` - n8n webhook communication
 - `taskDetectorService.js` - Detects automated task generation requests (optional)
+- `messageConsolidator.js` - Consolidates multi-turn conversation into single prompt when no session ID provided
 
 **Model Loading System:**
 - `JsonFileModelLoader` (TYPE: `file`) - Default, reads `models.json`, hash-based hot-reload

--- a/src/handlers/nonStreamingHandler.js
+++ b/src/handlers/nonStreamingHandler.js
@@ -29,6 +29,7 @@ const { createCompletionResponse } = require('../utils/openaiResponse');
  * @param {Object} userContext - User context data
  * @param {string} model - Model identifier
  * @param {Object} config - Configuration object
+ * @param {string} sessionSource - Source of session ID
  * @returns {Promise<void>}
  */
 async function handleNonStreaming(
@@ -40,12 +41,14 @@ async function handleNonStreaming(
   userContext,
   model,
   config,
+  sessionSource,
 ) {
   const content = await n8nClient.nonStreamingCompletion(
     webhookUrl,
     messages,
     sessionId,
     userContext,
+    sessionSource,
   );
 
   const response = createCompletionResponse(model, content);

--- a/src/handlers/streamingHandler.js
+++ b/src/handlers/streamingHandler.js
@@ -30,6 +30,7 @@ const { createErrorResponse } = require('../utils/errorResponse');
  * @param {Object} userContext - User context data
  * @param {string} model - Model identifier
  * @param {Object} config - Configuration object
+ * @param {string} sessionSource - Source of session ID
  * @returns {Promise<void>}
  */
 async function handleStreaming(
@@ -41,6 +42,7 @@ async function handleStreaming(
   userContext,
   model,
   config,
+  sessionSource,
 ) {
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
@@ -52,6 +54,7 @@ async function handleStreaming(
       messages,
       sessionId,
       userContext,
+      sessionSource,
     );
 
     for await (const content of streamGenerator) {

--- a/src/n8nClient.js
+++ b/src/n8nClient.js
@@ -25,6 +25,7 @@ const {
   extractTextFromMultimodal,
   isMultimodalMessage,
 } = require('./utils/fileProcessor');
+const { consolidateMessages } = require('./utils/messageConsolidator');
 
 class N8nClient {
   /** @type {Set<string>} Chunk types treated as metadata (no content extracted) */
@@ -44,7 +45,7 @@ class N8nClient {
     return headers;
   }
 
-  buildPayload(messages, sessionId, userContext) {
+  buildPayload(messages, sessionId, userContext, sessionSource) {
     const fileUploadMode = this.config.fileUploadMode || 'passthrough';
 
     // Process messages according to file upload mode
@@ -60,11 +61,22 @@ class N8nClient {
 
     // Extract current message (handle multimodal content)
     const lastMessage = processedMessages[processedMessages.length - 1];
-    const currentMessage = lastMessage
+    let currentMessage = lastMessage
       ? isMultimodalMessage(lastMessage)
         ? extractTextFromMultimodal(lastMessage)
         : lastMessage.content || ''
       : '';
+
+    // Consolidate messages when session is generated (no session ID provided)
+    // This preserves conversation context for n8n workflows that only read chatInput
+    const isGeneratedSession = sessionSource === 'generated (new UUID)';
+    if (isGeneratedSession) {
+      const nonSystemMessages = processedMessages.filter((m) => m.role !== 'system');
+      if (nonSystemMessages.length > 1) {
+        const consolidated = consolidateMessages(nonSystemMessages);
+        currentMessage = consolidated;
+      }
+    }
 
     const payload = {
       systemPrompt,
@@ -223,8 +235,8 @@ class N8nClient {
     };
   }
 
-  async *streamCompletion(webhookUrl, messages, sessionId, userContext) {
-    const payload = this.buildPayload(messages, sessionId, userContext);
+  async *streamCompletion(webhookUrl, messages, sessionId, userContext, sessionSource) {
+    const payload = this.buildPayload(messages, sessionId, userContext, sessionSource);
     const files = this._pendingFiles || [];
     this._pendingFiles = [];
 
@@ -244,8 +256,8 @@ class N8nClient {
     }
   }
 
-  async nonStreamingCompletion(webhookUrl, messages, sessionId, userContext) {
-    const payload = this.buildPayload(messages, sessionId, userContext);
+  async nonStreamingCompletion(webhookUrl, messages, sessionId, userContext, sessionSource) {
+    const payload = this.buildPayload(messages, sessionId, userContext, sessionSource);
     const files = this._pendingFiles || [];
     this._pendingFiles = [];
 

--- a/src/routes/chatCompletions.js
+++ b/src/routes/chatCompletions.js
@@ -119,6 +119,7 @@ router.post('/', async (req, res) => {
         userContext,
         model,
         config,
+        sessionSource,
       );
     } else {
       await handleNonStreaming(
@@ -130,6 +131,7 @@ router.post('/', async (req, res) => {
         userContext,
         model,
         config,
+        sessionSource,
       );
     }
   } catch (error) {

--- a/src/utils/messageConsolidator.js
+++ b/src/utils/messageConsolidator.js
@@ -1,0 +1,52 @@
+/*
+ * n8n OpenAI Bridge
+ * Copyright (C) 2025 Sven Eisenschmidt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { extractTextFromMultimodal, isMultimodalMessage } = require('./fileProcessor');
+
+/**
+ * Consolidates an array of messages into a single string with XML-like tags.
+ * Used when session ID is generated to preserve conversation context for
+ * n8n workflows that only read chatInput/currentMessage.
+ *
+ * @param {Array<Object>} messages - Array of message objects with role and content
+ * @returns {string} Consolidated string with XML-like tags
+ */
+function consolidateMessages(messages) {
+  if (!messages || messages.length === 0) {
+    return '';
+  }
+
+  if (messages.length === 1) {
+    const msg = messages[0];
+    const content = isMultimodalMessage(msg) ? extractTextFromMultimodal(msg) : msg.content || '';
+    return content;
+  }
+
+  const parts = messages.map((msg) => {
+    const content = isMultimodalMessage(msg) ? extractTextFromMultimodal(msg) : msg.content || '';
+
+    const role = msg.role || 'unknown';
+    return `<${role}>${content}</${role}>`;
+  });
+
+  return parts.join('');
+}
+
+module.exports = {
+  consolidateMessages,
+};

--- a/tests/n8n-client/build-payload.test.js
+++ b/tests/n8n-client/build-payload.test.js
@@ -29,7 +29,12 @@ describe('buildPayload - Edge Cases', () => {
     const messages = [{ role: 'user', content: longMessage }];
 
     const userContext = { userId: 'test-user' };
-    const payload = client.buildPayload(messages, 'session-123', userContext);
+    const payload = client.buildPayload(
+      messages,
+      'session-123',
+      userContext,
+      'req.body.session_id',
+    );
 
     expect(payload.currentMessage).toBe(longMessage);
     expect(payload.currentMessage.length).toBe(10000);
@@ -39,7 +44,12 @@ describe('buildPayload - Edge Cases', () => {
     const messages = [{ role: 'user', content: 'Test with \n newlines \t tabs and "quotes"' }];
 
     const userContext = { userId: 'test-user' };
-    const payload = client.buildPayload(messages, 'session-123', userContext);
+    const payload = client.buildPayload(
+      messages,
+      'session-123',
+      userContext,
+      'req.body.session_id',
+    );
 
     expect(payload.currentMessage).toContain('\n');
     expect(payload.currentMessage).toContain('\t');
@@ -56,7 +66,12 @@ describe('buildPayload - Edge Cases', () => {
       userRole: '',
     };
 
-    const payload = client.buildPayload(messages, 'session-123', userContext);
+    const payload = client.buildPayload(
+      messages,
+      'session-123',
+      userContext,
+      'req.body.session_id',
+    );
 
     expect(payload.userId).toBe('');
     expect(payload).not.toHaveProperty('userEmail');
@@ -74,12 +89,153 @@ describe('buildPayload - Edge Cases', () => {
       userRole: '',
     };
 
-    const payload = client.buildPayload(messages, 'session-123', userContext);
+    const payload = client.buildPayload(
+      messages,
+      'session-123',
+      userContext,
+      'req.body.session_id',
+    );
 
     expect(payload.userId).toBe('test-user');
     // undefined, null, and empty string should all be excluded
     expect(payload).not.toHaveProperty('userEmail');
     expect(payload).not.toHaveProperty('userName');
     expect(payload).not.toHaveProperty('userRole');
+  });
+});
+
+describe('buildPayload - Message Consolidation', () => {
+  let client;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = createTestClient();
+  });
+
+  test('should consolidate messages when session is generated and multiple messages exist', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+      { role: 'user', content: 'How are you?' },
+    ];
+
+    const userContext = { userId: 'test-user' };
+    const payload = client.buildPayload(
+      messages,
+      'generated-uuid-123',
+      userContext,
+      'generated (new UUID)',
+    );
+
+    expect(payload.currentMessage).toBe(
+      '<user>Hello</user><assistant>Hi there!</assistant><user>How are you?</user>',
+    );
+    expect(payload.chatInput).toBe(
+      '<user>Hello</user><assistant>Hi there!</assistant><user>How are you?</user>',
+    );
+    // messages array should remain unchanged for backward compatibility
+    expect(payload.messages).toHaveLength(3);
+  });
+
+  test('should not consolidate when session is provided (not generated)', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+      { role: 'user', content: 'How are you?' },
+    ];
+
+    const userContext = { userId: 'test-user' };
+    const payload = client.buildPayload(
+      messages,
+      'user-session-123',
+      userContext,
+      'req.body.session_id',
+    );
+
+    // Should only contain the last message
+    expect(payload.currentMessage).toBe('How are you?');
+    expect(payload.chatInput).toBe('How are you?');
+  });
+
+  test('should not consolidate when session is generated but only one message exists', () => {
+    const messages = [{ role: 'user', content: 'Hello' }];
+
+    const userContext = { userId: 'test-user' };
+    const payload = client.buildPayload(
+      messages,
+      'generated-uuid-123',
+      userContext,
+      'generated (new UUID)',
+    );
+
+    // Single message should be returned as-is (no wrapping)
+    expect(payload.currentMessage).toBe('Hello');
+    expect(payload.chatInput).toBe('Hello');
+  });
+
+  test('should exclude system messages from consolidation', () => {
+    const messages = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+      { role: 'user', content: 'How are you?' },
+    ];
+
+    const userContext = { userId: 'test-user' };
+    const payload = client.buildPayload(
+      messages,
+      'generated-uuid-123',
+      userContext,
+      'generated (new UUID)',
+    );
+
+    // System message should be extracted separately
+    expect(payload.systemPrompt).toBe('You are a helpful assistant.');
+    // Consolidation should only include non-system messages
+    expect(payload.currentMessage).toBe(
+      '<user>Hello</user><assistant>Hi there!</assistant><user>How are you?</user>',
+    );
+    // messages array should exclude system message
+    expect(payload.messages).toHaveLength(3);
+  });
+
+  test('should handle consolidation with undefined sessionSource', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there!' },
+    ];
+
+    const userContext = { userId: 'test-user' };
+    const payload = client.buildPayload(messages, 'session-123', userContext, undefined);
+
+    // Should behave as if session was provided (no consolidation)
+    expect(payload.currentMessage).toBe('Hi there!');
+  });
+
+  test('should handle consolidation with multimodal content', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is this?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,abc' } },
+        ],
+      },
+      { role: 'assistant', content: 'It is an image.' },
+      { role: 'user', content: 'Thanks!' },
+    ];
+
+    const userContext = { userId: 'test-user' };
+    const payload = client.buildPayload(
+      messages,
+      'generated-uuid-123',
+      userContext,
+      'generated (new UUID)',
+    );
+
+    // Should extract text from multimodal and consolidate
+    expect(payload.currentMessage).toBe(
+      '<user>What is this?</user><assistant>It is an image.</assistant><user>Thanks!</user>',
+    );
   });
 });

--- a/tests/n8n-client/file-upload-modes.test.js
+++ b/tests/n8n-client/file-upload-modes.test.js
@@ -48,7 +48,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should preserve multimodal content as-is', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       // Messages should be unchanged
       expect(payload.messages[0].content).toEqual(multimodalMessage.content);
@@ -57,7 +62,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should extract text for currentMessage', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.currentMessage).toBe('What is in this image?');
       expect(payload.chatInput).toBe('What is in this image?');
@@ -65,7 +75,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should handle simple messages normally', () => {
       const messages = [simpleMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.messages[0].content).toBe('Hello');
       expect(payload.currentMessage).toBe('Hello');
@@ -81,7 +96,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should extract files to separate array', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.files).toHaveLength(1);
       expect(payload.files[0]).toEqual({
@@ -93,14 +113,24 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should replace message content with text only', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.messages[0].content).toBe('What is in this image?');
     });
 
     test('should not include files array when no files present', () => {
       const messages = [simpleMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.files).toBeUndefined();
     });
@@ -116,7 +146,12 @@ describe('N8nClient - File Upload Modes', () => {
           ],
         },
       ];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.files).toHaveLength(2);
       expect(payload.files[0].name).toBe('message_0_file_0.png');
@@ -133,7 +168,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should store files for multipart upload', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       // Files should NOT be in payload (they go in multipart form)
       expect(payload.files).toBeUndefined();
@@ -145,7 +185,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should replace message content with text only', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.messages[0].content).toBe('What is in this image?');
     });
@@ -160,7 +205,12 @@ describe('N8nClient - File Upload Modes', () => {
 
     test('should strip files and keep only text', () => {
       const messages = [multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.messages[0].content).toBe('What is in this image?');
       expect(payload.files).toBeUndefined();
@@ -173,7 +223,12 @@ describe('N8nClient - File Upload Modes', () => {
         content: [{ type: 'image_url', image_url: { url: sampleDataUrl } }],
       };
       const messages = [imageOnlyMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.messages[0].content).toBe('');
       expect(payload.currentMessage).toBe('');
@@ -191,7 +246,12 @@ describe('N8nClient - File Upload Modes', () => {
       };
       const client = createTestClient({ fileUploadMode: 'extract-json' });
       const messages = [multimodalSystem, simpleMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.systemPrompt).toBe('You are a vision assistant');
     });
@@ -199,7 +259,12 @@ describe('N8nClient - File Upload Modes', () => {
     test('should handle simple system message normally', () => {
       const client = createTestClient({ fileUploadMode: 'passthrough' });
       const messages = [systemMessage, simpleMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.systemPrompt).toBe('You are a helpful assistant');
     });
@@ -209,7 +274,12 @@ describe('N8nClient - File Upload Modes', () => {
     test('should handle mix of simple and multimodal messages', () => {
       const client = createTestClient({ fileUploadMode: 'extract-json' });
       const messages = [systemMessage, simpleMessage, multimodalMessage];
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.systemPrompt).toBe('You are a helpful assistant');
       expect(payload.messages).toHaveLength(2); // Excludes system

--- a/tests/n8n-client/http-errors.test.js
+++ b/tests/n8n-client/http-errors.test.js
@@ -44,6 +44,7 @@ describe('N8nClient - HTTP Error Responses', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       ),
     ).rejects.toMatchObject({
       response: {
@@ -68,6 +69,7 @@ describe('N8nClient - HTTP Error Responses', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       ),
     ).rejects.toMatchObject({
       response: {
@@ -92,6 +94,7 @@ describe('N8nClient - HTTP Error Responses', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       ),
     ).rejects.toMatchObject({
       response: {

--- a/tests/n8n-client/malformed-response.test.js
+++ b/tests/n8n-client/malformed-response.test.js
@@ -43,6 +43,7 @@ describe('N8nClient - Malformed Response Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toBe('');
@@ -65,6 +66,7 @@ describe('N8nClient - Malformed Response Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toBe('');
@@ -87,6 +89,7 @@ describe('N8nClient - Malformed Response Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     // Should only collect valid chunks
@@ -110,6 +113,7 @@ describe('N8nClient - Malformed Response Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toBe('Hello World');
@@ -136,6 +140,7 @@ describe('N8nClient - Malformed Response Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result.length).toBeGreaterThan(90000);

--- a/tests/n8n-client/network-errors.test.js
+++ b/tests/n8n-client/network-errors.test.js
@@ -43,6 +43,7 @@ describe('N8nClient - Network Errors', () => {
           [{ role: 'user', content: 'Hello' }],
           'session-123',
           userContext,
+          'req.body.session_id',
         )
         .next(),
     ).rejects.toMatchObject({
@@ -64,6 +65,7 @@ describe('N8nClient - Network Errors', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       ),
     ).rejects.toMatchObject({
       code: 'ENOTFOUND',
@@ -84,6 +86,7 @@ describe('N8nClient - Network Errors', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       ),
     ).rejects.toMatchObject({
       code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',

--- a/tests/n8n-client/special-characters.test.js
+++ b/tests/n8n-client/special-characters.test.js
@@ -43,6 +43,7 @@ describe('N8nClient - Special Characters', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toBe('Hello 世界 🌍');
@@ -74,6 +75,7 @@ describe('N8nClient - Special Characters', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toBe('nächste');
@@ -94,6 +96,7 @@ describe('N8nClient - Special Characters', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toContain('Line 1');
@@ -115,6 +118,7 @@ describe('N8nClient - Special Characters', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     expect(result).toContain('Hello');

--- a/tests/n8n-client/task-detection.test.js
+++ b/tests/n8n-client/task-detection.test.js
@@ -24,7 +24,12 @@ describe('N8nClient - Task Detection', () => {
       const sessionId = 'test-session';
       const userContext = { userId: 'user-123' };
 
-      const payload = n8nClient.buildPayload(messages, sessionId, userContext);
+      const payload = n8nClient.buildPayload(
+        messages,
+        sessionId,
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(false);
       expect(payload.taskType).toBe(null);
@@ -34,7 +39,7 @@ describe('N8nClient - Task Detection', () => {
       const detectSpy = jest.spyOn(taskDetectorService, 'detectTask');
       const messages = [{ role: 'user', content: 'Test' }];
 
-      n8nClient.buildPayload(messages, 'session', { userId: 'user' });
+      n8nClient.buildPayload(messages, 'session', { userId: 'user' }, 'req.body.session_id');
 
       expect(detectSpy).not.toHaveBeenCalled();
     });
@@ -58,7 +63,12 @@ describe('N8nClient - Task Detection', () => {
         },
       ];
 
-      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+      const payload = n8nClient.buildPayload(
+        messages,
+        'session-123',
+        { userId: 'user-123' },
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(true);
       expect(payload.taskType).toBe(TaskType.GENERATE_TITLE);
@@ -77,7 +87,12 @@ describe('N8nClient - Task Detection', () => {
         },
       ];
 
-      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+      const payload = n8nClient.buildPayload(
+        messages,
+        'session-123',
+        { userId: 'user-123' },
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(true);
       expect(payload.taskType).toBe(TaskType.GENERATE_TAGS);
@@ -95,7 +110,12 @@ describe('N8nClient - Task Detection', () => {
         },
       ];
 
-      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+      const payload = n8nClient.buildPayload(
+        messages,
+        'session-123',
+        { userId: 'user-123' },
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(true);
       expect(payload.taskType).toBe(TaskType.GENERATE_FOLLOW_UP_QUESTIONS);
@@ -107,7 +127,12 @@ describe('N8nClient - Task Detection', () => {
 
       const messages = [{ role: 'user', content: 'Hello, how are you?' }];
 
-      const payload = n8nClient.buildPayload(messages, 'session-123', { userId: 'user-123' });
+      const payload = n8nClient.buildPayload(
+        messages,
+        'session-123',
+        { userId: 'user-123' },
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(false);
       expect(payload.taskType).toBe(null);
@@ -128,7 +153,12 @@ describe('N8nClient - Task Detection', () => {
         userRole: 'admin',
       };
 
-      const payload = n8nClient.buildPayload(messages, 'session-abc', userContext);
+      const payload = n8nClient.buildPayload(
+        messages,
+        'session-abc',
+        userContext,
+        'req.body.session_id',
+      );
 
       // Standard fields
       expect(payload.systemPrompt).toBe('System prompt');
@@ -150,9 +180,14 @@ describe('N8nClient - Task Detection', () => {
       const n8nClientWithoutDetector = new N8nClient(config, null);
 
       const messages = [{ role: 'user', content: 'Test' }];
-      const payload = n8nClientWithoutDetector.buildPayload(messages, 'session', {
-        userId: 'user',
-      });
+      const payload = n8nClientWithoutDetector.buildPayload(
+        messages,
+        'session',
+        {
+          userId: 'user',
+        },
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(false);
       expect(payload.taskType).toBe(null);
@@ -165,7 +200,12 @@ describe('N8nClient - Task Detection', () => {
       const n8nClientDisabled = new N8nClient(config, null);
 
       const messages = [{ role: 'user', content: 'Test' }];
-      const payload = n8nClientDisabled.buildPayload(messages, 'session', { userId: 'user' });
+      const payload = n8nClientDisabled.buildPayload(
+        messages,
+        'session',
+        { userId: 'user' },
+        'req.body.session_id',
+      );
 
       expect(payload).toHaveProperty('isTask');
       expect(payload).toHaveProperty('taskType');
@@ -181,14 +221,24 @@ describe('N8nClient - Task Detection', () => {
       // With detection disabled
       config.enableTaskDetection = false;
       const clientDisabled = new N8nClient(config, taskDetectorService);
-      const payloadDisabled = clientDisabled.buildPayload(messages, sessionId, userContext);
+      const payloadDisabled = clientDisabled.buildPayload(
+        messages,
+        sessionId,
+        userContext,
+        'req.body.session_id',
+      );
 
       // With detection enabled but no match
       config.enableTaskDetection = true;
       const clientEnabled = new N8nClient(config, taskDetectorService);
       const detector = jest.fn().mockReturnValue(false);
       taskDetectorService.registerDetector(TaskType.GENERATE_TITLE, detector);
-      const payloadEnabled = clientEnabled.buildPayload(messages, sessionId, userContext);
+      const payloadEnabled = clientEnabled.buildPayload(
+        messages,
+        sessionId,
+        userContext,
+        'req.body.session_id',
+      );
 
       // Both should have the same structure
       expect(Object.keys(payloadDisabled).sort()).toEqual(Object.keys(payloadEnabled).sort());
@@ -211,7 +261,12 @@ describe('N8nClient - Task Detection', () => {
       taskDetectorService.registerDetector(TaskType.GENERATE_FOLLOW_UP_QUESTIONS, followUpDetector);
 
       const messages = [{ role: 'user', content: 'Test' }];
-      const payload = n8nClient.buildPayload(messages, 'session', { userId: 'user' });
+      const payload = n8nClient.buildPayload(
+        messages,
+        'session',
+        { userId: 'user' },
+        'req.body.session_id',
+      );
 
       expect(payload.isTask).toBe(true);
       expect(payload.taskType).toBe(TaskType.GENERATE_TAGS);
@@ -225,7 +280,7 @@ describe('N8nClient - Task Detection', () => {
       taskDetectorService.registerDetector(TaskType.GENERATE_TAGS, tagsDetector);
 
       const messages = [{ role: 'user', content: 'Test' }];
-      n8nClient.buildPayload(messages, 'session', { userId: 'user' });
+      n8nClient.buildPayload(messages, 'session', { userId: 'user' }, 'req.body.session_id');
 
       expect(titleDetector).toHaveBeenCalled();
       // tagsDetector may or may not be called depending on Map iteration order

--- a/tests/n8n-client/timeout.test.js
+++ b/tests/n8n-client/timeout.test.js
@@ -42,6 +42,7 @@ describe('N8nClient - Timeout Handling', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       ),
     ).rejects.toMatchObject({
       code: 'ECONNABORTED',
@@ -65,6 +66,7 @@ describe('N8nClient - Timeout Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     // Verify timeout is configured
@@ -94,6 +96,7 @@ describe('N8nClient - Timeout Handling', () => {
       [{ role: 'user', content: 'Hello' }],
       'session-123',
       userContext,
+      'req.body.session_id',
     );
 
     // Verify custom timeout is used

--- a/tests/n8nClient.test.js
+++ b/tests/n8nClient.test.js
@@ -61,7 +61,12 @@ describe('N8nClient', () => {
         userRole: 'admin',
       };
 
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.systemPrompt).toBe('You are a helpful assistant');
       expect(payload.currentMessage).toBe('How are you?');
@@ -81,7 +86,12 @@ describe('N8nClient', () => {
       ];
 
       const userContext = { userId: 'user-456' };
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.messages).toHaveLength(2);
       expect(payload.messages.every((m) => m.role !== 'system')).toBe(true);
@@ -89,7 +99,7 @@ describe('N8nClient', () => {
 
     test('should handle empty messages array', () => {
       const userContext = { userId: 'user-456' };
-      const payload = client.buildPayload([], 'session-123', userContext);
+      const payload = client.buildPayload([], 'session-123', userContext, 'req.body.session_id');
 
       expect(payload.systemPrompt).toBe('');
       expect(payload.currentMessage).toBe('');
@@ -106,7 +116,12 @@ describe('N8nClient', () => {
         userRole: null,
       };
 
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.userId).toBe('user-456');
       expect(payload).not.toHaveProperty('userEmail');
@@ -124,7 +139,12 @@ describe('N8nClient', () => {
         userRole: 'admin',
       };
 
-      const payload = client.buildPayload(messages, 'session-123', userContext);
+      const payload = client.buildPayload(
+        messages,
+        'session-123',
+        userContext,
+        'req.body.session_id',
+      );
 
       expect(payload.userId).toBe('user-456');
       expect(payload.userEmail).toBe('user@example.com');
@@ -155,6 +175,7 @@ describe('N8nClient', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       );
 
       expect(result).toBe('Hello World');
@@ -178,6 +199,7 @@ describe('N8nClient', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       );
 
       expect(result).toBe('Complete response');
@@ -202,6 +224,7 @@ describe('N8nClient', () => {
         [{ role: 'user', content: 'Hello' }],
         'session-123',
         userContext,
+        'req.body.session_id',
       );
 
       expect(result).toBe('Part 1 Part 2 Part 3');
@@ -217,6 +240,7 @@ describe('N8nClient', () => {
           [{ role: 'user', content: 'Hello' }],
           'session-123',
           userContext,
+          'req.body.session_id',
         ),
       ).rejects.toThrow('Network error');
     });

--- a/tests/routes/chatCompletions.test.js
+++ b/tests/routes/chatCompletions.test.js
@@ -202,6 +202,7 @@ describe('chatCompletions route', () => {
           [{ role: 'user', content: 'Hello' }],
           'session-123',
           expect.objectContaining({ userId: 'anonymous' }),
+          'headers[X-Session-Id]',
         );
       });
 
@@ -229,6 +230,7 @@ describe('chatCompletions route', () => {
             userName: 'Test User',
             userRole: 'admin',
           },
+          expect.any(String),
         );
       });
 
@@ -327,6 +329,7 @@ describe('chatCompletions route', () => {
           [{ role: 'user', content: 'Hello' }],
           'session-789',
           expect.objectContaining({ userId: 'user-123' }),
+          'headers[X-Session-Id]',
         );
       });
     });

--- a/tests/utils/messageConsolidator.test.js
+++ b/tests/utils/messageConsolidator.test.js
@@ -1,0 +1,194 @@
+/**
+ * Tests for messageConsolidator utility
+ *
+ * Copyright (c) 2025 Sven Eisenschmidt
+ * Licensed under AGPL-3.0
+ */
+
+const { consolidateMessages } = require('../../src/utils/messageConsolidator');
+
+describe('messageConsolidator', () => {
+  describe('single message', () => {
+    test('should return content as-is for single user message', () => {
+      const messages = [{ role: 'user', content: 'Hello' }];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('Hello');
+    });
+
+    test('should return content as-is for single assistant message', () => {
+      const messages = [{ role: 'assistant', content: 'Hi there!' }];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('Hi there!');
+    });
+
+    test('should handle empty content in single message', () => {
+      const messages = [{ role: 'user', content: '' }];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('');
+    });
+
+    test('should handle missing content in single message', () => {
+      const messages = [{ role: 'user' }];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('multiple messages', () => {
+    test('should wrap messages with XML-like tags', () => {
+      const messages = [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+        { role: 'user', content: 'How are you?' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe(
+        '<user>Hello</user><assistant>Hi there!</assistant><user>How are you?</user>',
+      );
+    });
+
+    test('should handle user and assistant roles', () => {
+      const messages = [
+        { role: 'user', content: 'What is 2+2?' },
+        { role: 'assistant', content: '4' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>What is 2+2?</user><assistant>4</assistant>');
+    });
+
+    test('should handle tool role', () => {
+      const messages = [
+        { role: 'user', content: 'Check the weather' },
+        { role: 'tool', content: 'Sunny, 72F' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>Check the weather</user><tool>Sunny, 72F</tool>');
+    });
+
+    test('should handle function role', () => {
+      const messages = [
+        { role: 'user', content: 'Call API' },
+        { role: 'function', content: '{"status": "ok"}' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>Call API</user><function>{"status": "ok"}</function>');
+    });
+
+    test('should handle unknown roles by using role name as tag', () => {
+      const messages = [
+        { role: 'user', content: 'Hello' },
+        { role: 'custom', content: 'Custom response' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>Hello</user><custom>Custom response</custom>');
+    });
+
+    test('should handle missing role by using "unknown"', () => {
+      const messages = [{ role: 'user', content: 'Hello' }, { content: 'No role' }];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>Hello</user><unknown>No role</unknown>');
+    });
+
+    test('should handle empty content in messages', () => {
+      const messages = [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'How are you?' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>Hello</user><assistant></assistant><user>How are you?</user>');
+    });
+  });
+
+  describe('multimodal content', () => {
+    test('should extract text from multimodal message', () => {
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,abc123' },
+            },
+          ],
+        },
+        { role: 'assistant', content: 'It is a cat.' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user>What is in this image?</user><assistant>It is a cat.</assistant>');
+    });
+
+    test('should handle multiple text parts in multimodal message', () => {
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'First part' },
+            { type: 'text', text: 'Second part' },
+          ],
+        },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('First part\nSecond part');
+    });
+
+    test('should handle multimodal with no text parts', () => {
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,abc123' },
+            },
+          ],
+        },
+        { role: 'assistant', content: 'I see an image.' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe('<user></user><assistant>I see an image.</assistant>');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should return empty string for empty array', () => {
+      const result = consolidateMessages([]);
+      expect(result).toBe('');
+    });
+
+    test('should return empty string for null', () => {
+      const result = consolidateMessages(null);
+      expect(result).toBe('');
+    });
+
+    test('should return empty string for undefined', () => {
+      const result = consolidateMessages(undefined);
+      expect(result).toBe('');
+    });
+
+    test('should handle special characters in content', () => {
+      const messages = [
+        { role: 'user', content: 'Test with \n newlines \t tabs and "quotes"' },
+        { role: 'assistant', content: 'Response with <xml> tags' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toContain('\n');
+      expect(result).toContain('\t');
+      expect(result).toContain('"');
+      expect(result).toContain('<xml>');
+    });
+
+    test('should handle very long content', () => {
+      const longContent = 'A'.repeat(10000);
+      const messages = [
+        { role: 'user', content: longContent },
+        { role: 'assistant', content: 'OK' },
+      ];
+      const result = consolidateMessages(messages);
+      expect(result).toBe(`<user>${longContent}</user><assistant>OK</assistant>`);
+      // 10000 (longContent) + 2 (OK) + 36 (tags: <user></user><assistant></assistant>)
+      expect(result.length).toBe(10038);
+    });
+  });
+});


### PR DESCRIPTION
## Description

When an OpenAI client sends a chat completion request without a session ID, the system generates a random UUID each time, making it impossible for n8n workflows to correlate requests across conversation turns. While the `messages` array in the payload contains full conversation history, n8n workflows often only read `chatInput`/`currentMessage` (the last message), causing all prior context to be lost.

This PR adds automatic conversation history consolidation when no session ID is provided. When the session ID is randomly generated (`sessionSource === 'generated (new UUID)'`), all non-system messages are merged into a single prompt string using XML-like role tags:

```
<user>first prompt</user>
<assistant>response</assistant>
<user>second prompt</user>
```

This consolidated string replaces `currentMessage` and `chatInput` in the n8n payload, ensuring workflows that only read `chatInput` (such as the `n8n_workflow_chat.json` example) still receive the full conversation context. The `messages` array remains unchanged for backward compatibility.

If OpenAI client provides a deterministic session ID, then this consolidation is not applied, and the message is passed to N8N as is.

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #(issue)

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass (`make test`)
- [ ] Docker build succeeds
- [x] Manual testing performed

**Test Configuration:**
- Docker version:
- OS:

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->
